### PR TITLE
Feature/jsonld compact

### DIFF
--- a/badgecheck/tasks/__init__.py
+++ b/badgecheck/tasks/__init__.py
@@ -1,12 +1,15 @@
 from input import detect_input_type
 from graph import fetch_http_node, jsonld_compact_data
-from task_types import (DETECT_INPUT_TYPE, FETCH_HTTP_NODE, JSONLD_COMPACT_DATA)
+from validation import validate_primitive_property
+from task_types import (DETECT_INPUT_TYPE, FETCH_HTTP_NODE, JSONLD_COMPACT_DATA,
+                        VALIDATE_PRIMITIVE_PROPERTY)
 
 
 functions = {
     DETECT_INPUT_TYPE: detect_input_type,
     FETCH_HTTP_NODE: fetch_http_node,
-    JSONLD_COMPACT_DATA: jsonld_compact_data
+    JSONLD_COMPACT_DATA: jsonld_compact_data,
+    VALIDATE_PRIMITIVE_PROPERTY: validate_primitive_property,
 }
 
 

--- a/badgecheck/tasks/graph.py
+++ b/badgecheck/tasks/graph.py
@@ -2,7 +2,9 @@ import json
 from pyld import jsonld
 import requests
 
+from ..actions.graph import add_node
 from ..actions.tasks import add_task
+from ..util import CachableDocumentLoader, OPENBADGES_CONTEXT_URI_V2
 from task_types import JSONLD_COMPACT_DATA
 from utils import task_result
 
@@ -28,4 +30,16 @@ def fetch_http_node(state, task_meta):
 
 def jsonld_compact_data(state, task_meta):
     # TODO: Cache-friendly JSON-LD compaction into the Open Badges context
-    pass
+    input_data = json.loads(task_meta.get('data'))
+
+    node_id = task_meta.get('node_id')
+    options = {'documentLoader': CachableDocumentLoader(cachable=task_meta.get('use_cache', True))}
+
+    result = jsonld.compact(input_data, OPENBADGES_CONTEXT_URI_V2, options=options)
+    actions = [add_node(node_id, data=result)]
+
+    return task_result(
+        True,
+        "Successfully compacted node {}".format(node_id or "with unknown id"),
+        actions
+    )

--- a/badgecheck/tasks/graph.py
+++ b/badgecheck/tasks/graph.py
@@ -23,7 +23,6 @@ def fetch_http_node(state, task_meta):
             return task_result(message='Successfully fetched image from {}'.format(url))
         return task_result(success=False, message="Response could not be interpreted from url {}".format(url))
 
-    # TODO: Add JSON-LD COMPACTION
     actions = [add_task(JSONLD_COMPACT_DATA, data=data, node_id=url)]
     return task_result(message="Successfully fetched JSON data from {}".format(url), actions=actions)
 

--- a/badgecheck/tasks/task_types.py
+++ b/badgecheck/tasks/task_types.py
@@ -11,3 +11,11 @@ Fetch, store, and process nodes in the graph related to validation input.
 """
 FETCH_HTTP_NODE = 'FETCH_HTTP_NODE'
 JSONLD_COMPACT_DATA = 'JSONLD_COMPACT_DATA'
+
+
+"""
+VALIDATION Tasks:
+Ensure data is in good shape for relevant Open Badges objects and links between
+objects are sound.
+"""
+VALIDATE_PRIMITIVE_PROPERTY = 'VALIDATE_PRIMITIVE_PROPERTY'

--- a/badgecheck/tasks/validation.py
+++ b/badgecheck/tasks/validation.py
@@ -1,0 +1,106 @@
+import six
+
+from ..state import get_node_by_id
+
+from .utils import task_result
+
+
+class ValueTypes(object):
+    BOOLEAN = 'BOOLEAN'
+    DATETIME = 'DATETIME'
+    ID = 'ID'
+    IDENTITY_HASH = 'IDENTITY_HASH'
+    IRI = 'IRI'
+    MARKDOWN_TEXT = 'MARKDOWN_TEXT'
+    TEXT = 'TEXT'
+    URL = 'URL'
+
+
+class PrimitiveValueValidator(object):
+    """
+    A callable validator for primitive Open Badges value types. 
+    
+    Example usage: 
+    PrimitiveValueValidator(ValueTypes.TEXT)("test value")
+    > True
+    """
+    def __init__(self, value_type):
+        value_check_functions = {
+            ValueTypes.BOOLEAN: self._validate_boolean,
+            ValueTypes.DATETIME: self._validate_datetime,
+            ValueTypes.IDENTITY_HASH: self._validate_identity_hash,
+            ValueTypes.IRI: self._validate_iri,
+            ValueTypes.MARKDOWN_TEXT: self._validate_markdown_text,
+            ValueTypes.TEXT: self._validate_text,
+            ValueTypes.URL: self._validate_url
+        }
+        self.value_type = value_type
+        self.is_valid = value_check_functions[value_type]
+
+    def __call__(self, value):
+        return self.is_valid(value)
+
+    @staticmethod
+    def _validate_boolean(value):
+        return isinstance(value, bool)
+
+    @staticmethod
+    def _validate_datetime(value):
+        raise NotImplementedError("TODO: Add validator")
+
+    @staticmethod
+    def _validate_identity_hash(value):
+        raise NotImplementedError("TODO: Add validator")
+
+    @staticmethod
+    def _validate_iri(value):
+        raise NotImplementedError("TODO: Add validator")
+
+    @staticmethod
+    def _validate_markdown_text(value):
+        raise NotImplementedError("TODO: Add validator")
+
+    @staticmethod
+    def _validate_text(value):
+        return isinstance(value, six.string_types)
+
+    @staticmethod
+    def _validate_url(value):
+        raise NotImplementedError("TODO: Add validator")
+
+
+def validate_primitive_property(state, task_meta):
+    node_id = task_meta.get('node_id')
+    node = get_node_by_id(state, node_id)
+    node_class = task_meta.get('node_class', 'unknown type node')
+
+    prop_name = task_meta.get('prop_name')
+    prop_type = task_meta.get('prop_type')
+    prop_value = node.get(prop_name)
+    required = bool(task_meta.get('prop_required'))
+
+    if not prop_value and required:
+        return task_result(
+            False, "Required property {} not present in {} {}".format(
+                prop_name, node_class, node_id)
+        )
+
+    if not prop_value and not required:
+        return task_result(
+            True, "Optional property {} not present in {} {}".format(
+                prop_name, node_class, node_id)
+        )
+
+    value_check_function = PrimitiveValueValidator(prop_type)
+    if value_check_function(prop_value):
+        return task_result(
+            True, "{} property {} valid in {} {}".format(
+                prop_type, prop_name, node_class, node_id
+            )
+        )
+
+    return task_result(
+        False, "{} property {} not valid in {} {}".format(
+            prop_type, prop_name, node_class, node_id
+        )
+    )

--- a/badgecheck/util.py
+++ b/badgecheck/util.py
@@ -6,6 +6,9 @@ import requests
 import requests_cache
 
 
+OPENBADGES_CONTEXT_URI_V2 = "https://w3id.org/openbadges/v2"
+
+
 class CachableDocumentLoader(object):
     def __init__(self, cachable=False):
         self.cachable = cachable

--- a/badgecheck/verifier.py
+++ b/badgecheck/verifier.py
@@ -4,7 +4,7 @@ from actions.input import store_input
 from actions.tasks import add_task, resolve_task
 from exceptions import SkipTask
 from reducers import main_reducer
-import state
+from state import filter_active_tasks, INITIAL_STATE
 import tasks
 
 
@@ -40,14 +40,14 @@ def verify(badge_input):
     :param badge_input: str (url or json)
     :return: dict
     """
-    store = create_store(main_reducer, state.INITIAL_STATE)
+    store = create_store(main_reducer, INITIAL_STATE)
 
     store.dispatch(store_input(badge_input))
     store.dispatch(add_task(tasks.DETECT_INPUT_TYPE))
 
     last_task_id = 0
-    while len(state.filter_active_tasks(store.get_state())):
-        active_tasks = state.filter_active_tasks(store.get_state())
+    while len(filter_active_tasks(store.get_state())):
+        active_tasks = filter_active_tasks(store.get_state())
         task_meta = active_tasks[0]
         task_func = tasks.task_named(task_meta['name'])
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -142,6 +142,6 @@ class JsonLdCompactTests(unittest.TestCase):
         result, message, actions = jsonld_compact_data({}, task)
 
         state = graph_reducer([], actions[0])
-        self.assertEqual(len(state), 1)
+        self.assertEqual(len(state), 1, "Node should be added to graph")
         self.assertEqual(state[0]['name'], data['thing_we_call_you_by'])
-        self.assertIsNotNone(state[0].get('id'))
+        self.assertIsNotNone(state[0].get('id'), "Node should have a blank id assigned")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,3 +1,4 @@
+import json
 import responses
 import unittest
 
@@ -125,3 +126,22 @@ class JsonLdCompactTests(unittest.TestCase):
         self.assertEqual(
             actions[0]['data']['name'], "Test Data",
             "Node should be compacted into OB Context and use OB property names.")
+
+    @responses.activate
+    def test_reduce_compacted_output(self):
+        self.setUpContextCache()
+
+        data = {
+            "@context": {"thing_we_call_you_by": "http://schema.org/name"},
+            "thing_we_call_you_by": "Test Data"
+        }
+
+        task = add_task(JSONLD_COMPACT_DATA, data=json.dumps(data))
+        task['id'] = 1
+
+        result, message, actions = jsonld_compact_data({}, task)
+
+        state = graph_reducer([], actions[0])
+        self.assertEqual(len(state), 1)
+        self.assertEqual(state[0]['name'], data['thing_we_call_you_by'])
+        self.assertIsNotNone(state[0].get('id'))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,93 @@
+import unittest
+
+from badgecheck.actions.tasks import add_task
+from badgecheck.tasks.validation import validate_primitive_property, ValueTypes
+from badgecheck.tasks.task_types import VALIDATE_PRIMITIVE_PROPERTY
+
+
+class PropertyValidationTaskTests(unittest.TestCase):
+
+    def test_basic_text_property_validation(self):
+        first_node = {'id': 'http://example.com/1', 'string_prop': 'string value'}
+        state = {
+            'graph': [first_node]
+        }
+        task = add_task(
+            VALIDATE_PRIMITIVE_PROPERTY,
+            node_id=first_node['id'],
+            prop_name='string_prop',
+            prop_type=ValueTypes.TEXT,
+            prop_required=False
+        )
+        task['id'] = 1
+
+        result, message, actions = validate_primitive_property(state, task)
+        self.assertTrue(result, "Optional property is present and correct; validation should pass.")
+        self.assertEqual(
+            message, "TEXT property string_prop valid in unknown type node {}".format(first_node['id'])
+        )
+
+        task['prop_required'] = True
+        result, message, actions = validate_primitive_property(state, task)
+        self.assertTrue(result, "Required property is present and correct; validation should pass.")
+        self.assertEqual(
+            message, "TEXT property string_prop valid in unknown type node {}".format(first_node['id'])
+        )
+
+        first_node['string_prop'] = 1
+        result, message, actions = validate_primitive_property(state, task)
+        self.assertFalse(result, "Required string property is an int; validation should fail")
+        self.assertEqual(
+            message, "TEXT property string_prop not valid in unknown type node {}".format(first_node['id'])
+        )
+
+        task['prop_required'] = False
+        result, message, actions = validate_primitive_property(state, task)
+        self.assertFalse(result, "Optional string property is an int; validation should fail")
+        self.assertEqual(
+            message, "TEXT property string_prop not valid in unknown type node {}".format(first_node['id'])
+        )
+
+        # When property isn't present
+        second_node = {'id': 'http://example.com/1'}
+        state = {'graph': [second_node]}
+        result, message, actions = validate_primitive_property(state, task)
+        self.assertTrue(result, "Optional property is not present; validation should pass.")
+
+        task['prop_required'] = True
+        result, message, actions = validate_primitive_property(state, task)
+        self.assertFalse(result, "Required property is not present; validation should fail.")
+
+    def test_basic_boolean_property_validation(self):
+        first_node = {'id': 'http://example.com/1'}
+        state = {
+            'graph': [first_node]
+        }
+        task = add_task(
+            VALIDATE_PRIMITIVE_PROPERTY,
+            node_id=first_node['id'],
+            prop_name='bool_prop',
+            prop_required=False,
+            prop_type=ValueTypes.BOOLEAN
+        )
+        task['id'] = 1
+
+        result, message, actions = validate_primitive_property(state, task)
+        self.assertTrue(result, "Optional property is not present; validation should pass.")
+        self.assertEqual(
+            message, "Optional property bool_prop not present in unknown type node {}".format(first_node['id'])
+        )
+
+        task['prop_required'] = True
+        result, message, actions = validate_primitive_property(state, task)
+        self.assertFalse(result, "Required property is not present; validation should fail.")
+        self.assertEqual(
+            message, "Required property bool_prop not present in unknown type node {}".format(first_node['id'])
+        )
+
+        first_node['bool_prop'] = True
+        result, message, actions = validate_primitive_property(state, task)
+        self.assertTrue(result, "Required boolean property matches expectation")
+        self.assertEqual(
+            message, "BOOLEAN property bool_prop valid in unknown type node {}".format(first_node['id'])
+        )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -166,8 +166,8 @@ class PropertyValidationTaskTests(unittest.TestCase):
 
         state = store.get_state()
         self.assertEqual(len(state['tasks']), 5)
-        self.assertTrue(state['tasks'][0]['success'], )
-        self.assertTrue(state['tasks'][1]['success'])
-        self.assertTrue(state['tasks'][2]['success'])
-        self.assertFalse(state['tasks'][3]['success'])
-        self.assertFalse(state['tasks'][4]['success'])
+        self.assertTrue(state['tasks'][0]['success'], "Valid required text property is present.")
+        self.assertTrue(state['tasks'][1]['success'], "Missing optional text property is OK.")
+        self.assertTrue(state['tasks'][2]['success'], "Valid optional boolean property is present.")
+        self.assertFalse(state['tasks'][3]['success'], "Invalid required text property is present.")
+        self.assertFalse(state['tasks'][4]['success'], "Required boolean property is missing.")


### PR DESCRIPTION
Prerequisite PR (included here): #39 -- if you merge that first, changelog becomes simpler.

Adds a task handler for JSONLD_COMPACT_DATA. This task automatically triggers an add_node action with the result.

Important minor note: The input task_meta['data'] to this task is in string format, straight off the wire. The output is now a dict (as it is compacted into our common context) and can be worked with directly.