### PR TITLE
Feature/add url validator

### DIFF
--- a/badgecheck/tasks/validation.py
+++ b/badgecheck/tasks/validation.py
@@ -1,4 +1,5 @@
 import six
+import rfc3986
 
 from ..state import get_node_by_id
 
@@ -66,8 +67,15 @@ class PrimitiveValueValidator(object):
 
     @staticmethod
     def _validate_url(value):
-        raise NotImplementedError("TODO: Add validator")
-
+        ret = False
+        try:
+            if ((value and isinstance(value, six.string_types))
+                and rfc3986.is_valid_uri(value, require_scheme=True)
+                and rfc3986.uri_reference(value).scheme.lower() in ['http', 'https']):
+                ret = True
+        except ValueError as e:
+            pass
+        return ret
 
 def validate_primitive_property(state, task_meta):
     node_id = task_meta.get('node_id')

--- a/badgecheck/tasks/validation.py
+++ b/badgecheck/tasks/validation.py
@@ -1,5 +1,5 @@
-import six
 import rfc3986
+import six
 
 from ..state import get_node_by_id
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pydux==0.2.1
 PyLD==0.7.1
 requests >= 2.13
 requests_cache >= 0.4.13
+rfc3986==0.4.1
 validators==0.11.2
 
 # Development dependencies

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'pydux==0.2.1',
         'PyLD==0.7.1',
         'requests >= 2.13',
+        'rfc3986==0.4.1',
         'validators==0.11.2',
         # 'openbadges_bakery >= 0.1.4'  # Removing until openbadges_bakery does not require Django.
     ]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -98,6 +98,56 @@ class PropertyValidationTaskTests(unittest.TestCase):
             message, "BOOLEAN property bool_prop valid in unknown type node {}".format(first_node['id'])
         )
 
+    def test_basic_id_validation(self):
+        ## test assumes that a node's ID must be an IRI
+        first_node = {'id': 'http://example.com/1'}
+        state = {
+            'graph': [first_node]
+        }
+        task = add_task(
+            VALIDATE_PRIMITIVE_PROPERTY,
+            node_id=first_node['id'],
+            prop_name='id',
+            prop_required=True,
+            prop_type=ValueTypes.IRI
+        )
+        task['id']=1
+
+        # IRI validation not yet implemented
+        with self.assertRaises(NotImplementedError):
+            validate_primitive_property(state, task)
+
+    def test_basic_url_prop_validation(self):
+        _VALID_URL = 'http://example.com/2'
+        _INVALID_URL = 'notanurl'
+        first_node = {'id': 'http://example.com/1',
+                      'url_prop': _VALID_URL}
+        state = {
+            'graph': [first_node]
+        }
+
+        task = add_task(
+            VALIDATE_PRIMITIVE_PROPERTY,
+            node_id=first_node['id'],
+            prop_name='url_prop',
+            prop_required=False,
+            prop_type=ValueTypes.URL
+        )
+        task['id']=1
+
+        result, message, actions = validate_primitive_property(state, task)
+        self.assertTrue(result, "Optional URL prop is present and well-formed; validation should pass.")
+        self.assertEqual(
+            message, "URL property url_prop valid in unknown type node {}".format(first_node['id'])
+        )
+
+        first_node['url_prop'] = _INVALID_URL
+        result, message, actions = validate_primitive_property(state, task)
+        self.assertFalse(result, "Optional URL prop is present and mal-formed; validation should fail.")
+        self.assertEqual(
+             message, "URL property url_prop not valid in unknown type node {}".format(first_node['id'])
+        )
+
     def test_validation_action(self):
         store = create_store(main_reducer, INITIAL_STATE)
         first_node = {


### PR DESCRIPTION
Note that this can validate URIs that are URLs, but it doesn't validate IRIs or IRLs.

Currently, there seems no convenient way on Python of validating an IRI|L without writing the code from scratch, as the best library option seems to be `rfc3987` which is GPLv3'd and thus not usable by us.