### PR TITLE
Implements initial python API draft from #84.

### DIFF
--- a/badgecheck/actions/tasks.py
+++ b/badgecheck/actions/tasks.py
@@ -17,7 +17,7 @@ def add_task(task_name, **kwargs):
 def resolve_task(task_id, success=True, result=''):
     return {
         'type': RESOLVE_TASK,
-        'id': task_id,
+        'task_id': task_id,
         'success': success,
         'result': result
     }
@@ -26,7 +26,7 @@ def resolve_task(task_id, success=True, result=''):
 def delete_task(task_id):
     return {
         'type': DELETE_TASK,
-        'id': task_id
+        'task_id': task_id
     }
 
 
@@ -37,7 +37,7 @@ def update_task(task_id, task_name, **kwargs):
 
     task = {
         'type': UPDATE_TASK,
-        'id': task_id,
+        'task_id': task_id,
         'name': task_name,
     }
     task.update(**kwargs)

--- a/badgecheck/reducers/graph.py
+++ b/badgecheck/reducers/graph.py
@@ -24,10 +24,11 @@ def _flatten_node(node, node_id=None):
             node[prop] = prop_id
         elif isinstance(node[prop], list):
             current_list = node[prop]
-            for index in [i for i in range(len(current_list)) if isinstance(current_list[i], dict)]:
-                prop_id = current_list[i].get('id', _get_next_blank_node_id())
+            dict_indices = [i for i in range(len(current_list)) if isinstance(current_list[i], dict)]
+            for index in dict_indices:
+                prop_id = current_list[index].get('id', _get_next_blank_node_id())
                 node_list.extend(_flatten_node(current_list[index], prop_id))
-                current_list[i] = prop_id
+                current_list[index] = prop_id
 
     node_list.append(node)
     return node_list

--- a/badgecheck/reducers/tasks.py
+++ b/badgecheck/reducers/tasks.py
@@ -6,17 +6,17 @@ def task_reducer(state=None, action=None):
         state = []
         task_counter = 1
     else:
-        task_counter = state[-1]['id'] + 1
+        task_counter = state[-1]['task_id'] + 1
 
     if action.get('type') == ADD_TASK:
-        new_task = {'id': task_counter, 'complete': False}
+        new_task = {'task_id': task_counter, 'complete': False}
         for key in [k for k in action.keys() if k != 'type']:
             new_task[key] = action[key]
         return list(state) + [new_task]
 
     elif action.get('type') == RESOLVE_TASK:
         try:
-            task = [t for t in state if t['id'] == action['id']][0]
+            task = [t for t in state if t['task_id'] == action['task_id']][0]
         except KeyError:
             return state
         else:
@@ -26,18 +26,18 @@ def task_reducer(state=None, action=None):
                 'success': action.get('success'),
                 'result': action.get('result')
             })
-            return _new_state_with_updated_item(state, action['id'], update)
+            return _new_state_with_updated_item(state, action['task_id'], update)
 
     elif action.get('type') == UPDATE_TASK:
         try:
-            task = [t for t in state if t['id'] == action['id']][0]
+            task = [t for t in state if t['task_id'] == action['task_id']][0]
         except KeyError:
             return state
         else:
             update = task.copy()
-            for key in [k for k in action.keys() if k not in ('type', 'id',)]:
+            for key in [k for k in action.keys() if k not in ('type', 'task_id',)]:
                 update[key] = action[key]
-            return _new_state_with_updated_item(state, action['id'], update)
+            return _new_state_with_updated_item(state, action['task_id'], update)
 
 
     return state
@@ -46,7 +46,7 @@ def task_reducer(state=None, action=None):
 def _new_state_with_updated_item(state, item_id, update):
     new_state = []
     for i in range(0, len(state)):
-        if item_id != state[i].get('id'):
+        if item_id != state[i].get('task_id'):
             new_state.append(state[i])
         else:
             new_state.append(update)

--- a/badgecheck/state.py
+++ b/badgecheck/state.py
@@ -40,14 +40,16 @@ def filter_failed_tasks(state):
 def format_message(task_meta):
     ret = {
         'name': task_meta.get('name'),
-        'success': task_meta.get('success'),
-        'result': task_meta.get('result'),
+        'success': task_meta.get('success', False),
+        'result': task_meta.get('result', ''),
         'messageLevel': task_meta.get('messageLevel', MESSAGE_LEVEL_ERROR),
     }
     if task_meta.get('node_id'):
         ret['node_id'] = task_meta['node_id']
     if task_meta.get('prop_name'):
         ret['prop_name'] = task_meta['prop_name']
+    if not task_meta.get('complete') and not ret['result']:
+        ret['result'] = 'Task could not execute.'
 
     return ret
 

--- a/badgecheck/state.py
+++ b/badgecheck/state.py
@@ -6,6 +6,11 @@ INITIAL_STATE = {
     'tasks': []
 }
 
+MESSAGE_LEVEL_ERROR = 'ERROR'
+MESSAGE_LEVEL_WARNING = 'WARNING'
+MESSAGE_LEVEL_INFO = 'INFO'
+MESSAGE_LEVELS = (MESSAGE_LEVEL_ERROR, MESSAGE_LEVEL_WARNING, MESSAGE_LEVEL_INFO,)
+
 
 # Tasks
 def filter_active_tasks(state):
@@ -29,6 +34,22 @@ def filter_active_tasks(state):
 
 def filter_failed_tasks(state):
     return [t for t in state.get('tasks') if not t.get('success')]
+
+
+# Messages
+def format_message(task_meta):
+    ret = {
+        'name': task_meta.get('name'),
+        'success': task_meta.get('success'),
+        'result': task_meta.get('result'),
+        'messageLevel': task_meta.get('messageLevel', MESSAGE_LEVEL_ERROR),
+    }
+    if task_meta.get('node_id'):
+        ret['node_id'] = task_meta['node_id']
+    if task_meta.get('prop_name'):
+        ret['prop_name'] = task_meta['prop_name']
+
+    return ret
 
 
 # Graph

--- a/badgecheck/tasks/validation.py
+++ b/badgecheck/tasks/validation.py
@@ -551,10 +551,14 @@ def assertion_verification_dependencies(state, task_meta):
     """
     Performs and/or queues some security checks for hosted assertions.
     """
-    assertion_id = task_meta.get('node_id')
-    assertion_node = get_node_by_id(state, assertion_id)
-    node_id = assertion_node.get('verification')
-    node = get_node_by_id(state, node_id)
+    try:
+        assertion_id = task_meta['node_id']
+        assertion_node = get_node_by_id(state, assertion_id)
+        node_id = assertion_node['verification']
+        node = get_node_by_id(state, node_id)
+    except (IndexError, KeyError,):
+        raise TaskPrerequisitesError()
+
     actions = []
 
     if node.get('type') == 'HostedBadge':

--- a/badgecheck/verifier.py
+++ b/badgecheck/verifier.py
@@ -2,7 +2,7 @@ from pydux import create_store
 
 from .actions.input import store_input
 from .actions.tasks import add_task, resolve_task
-from .exceptions import SkipTask
+from .exceptions import SkipTask, TaskPrerequisitesError
 from .reducers import main_reducer
 from .state import (filter_active_tasks, filter_failed_tasks, format_message,
                     INITIAL_STATE, MESSAGE_LEVEL_ERROR, MESSAGE_LEVEL_WARNING,)
@@ -24,6 +24,9 @@ def call_task(task_func, task_meta, store):
     except SkipTask:
         # TODO: Implement skip handling.
         pass
+    except TaskPrerequisitesError:
+        message = "Task could not run due to unmet prerequisites."
+        store.dispatch(resolve_task(task_meta.get('task_id'), success=False, result=message))
     except Exception as e:
         message = "{} {}".format(e.__class__, e.message)
         store.dispatch(resolve_task(task_meta.get('task_id'), success=False, result=message))

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -17,14 +17,14 @@ class TaskActionTests(unittest.TestCase):
         self.store.dispatch(add_task('DETECT_INPUT_TYPE', **{'other': 123}))
         tasks = self.store.get_state().get('tasks')
         self.assertEqual(len(tasks), 1)
-        self.assertEqual(tasks[0]['id'], 1)
+        self.assertEqual(tasks[0]['task_id'], 1)
         self.assertEqual(tasks[0]['name'], 'DETECT_INPUT_TYPE')
         self.assertEqual(tasks[0]['other'], 123)
 
         self.store.dispatch(add_task('DETECT_INPUT_TYPE'))
         tasks = self.store.get_state().get('tasks')
         self.assertEqual(len(tasks), 2)
-        self.assertEqual(tasks[1]['id'], 2)
+        self.assertEqual(tasks[1]['task_id'], 2)
 
     def test_cannot_add_unknown_task(self):
         with self.assertRaises(AssertionError):
@@ -35,15 +35,15 @@ class TaskActionTests(unittest.TestCase):
         tasks = self.store.get_state().get('tasks')
         self.assertEqual(len(filter_active_tasks(self.store.get_state())), 1)
 
-        self.store.dispatch(resolve_task(tasks[0]['id']))
+        self.store.dispatch(resolve_task(tasks[0]['task_id']))
         tasks = self.store.get_state().get('tasks')
         self.assertTrue(tasks[0]['complete'])
         self.assertEqual(len(filter_active_tasks(self.store.get_state())), 0)
 
 
     def test_task_updater_internals(self):
-        initial = [{'id': 1}, {'id': 2}, {'id': 3}]
-        updated = _new_state_with_updated_item(initial, 2, {'id': 2, 'foo': 'bar'})
+        initial = [{'task_id': 1}, {'task_id': 2}, {'task_id': 3}]
+        updated = _new_state_with_updated_item(initial, 2, {'task_id': 2, 'foo': 'bar'})
         self.assertEqual(updated[1].get('foo'), 'bar')
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -122,7 +122,6 @@ class PropertyValidationTaskTests(unittest.TestCase):
             prop_type=ValueTypes.TEXT,
             required=False
         )
-        task['id'] = 1
 
         result, message, actions = validate_property(state, task)
         self.assertTrue(result, "Optional property is present and correct; validation should pass.")
@@ -167,7 +166,6 @@ class PropertyValidationTaskTests(unittest.TestCase):
             required=False,
             prop_type=ValueTypes.BOOLEAN
         )
-        task['id'] = 1
 
         result, message, actions = validate_property(state, task)
         self.assertTrue(result, "Optional property is not present; validation should pass.")
@@ -202,7 +200,6 @@ class PropertyValidationTaskTests(unittest.TestCase):
             required=True,
             prop_type=ValueTypes.IRI
         )
-        task['id'] = 1
 
         result, message, actions = validate_property(state, task)
         self.assertTrue(result)
@@ -226,7 +223,6 @@ class PropertyValidationTaskTests(unittest.TestCase):
             required=False,
             prop_type=ValueTypes.DATA_URI_OR_URL
         )
-        task['id'] = 1
 
         result, message, actions = validate_property(state, task)
         self.assertTrue(result, "Optional image_prop URI is present and well-formed; validation should pass.")
@@ -259,7 +255,6 @@ class PropertyValidationTaskTests(unittest.TestCase):
             required=False,
             prop_type=ValueTypes.URL
         )
-        task['id'] = 1
 
         result, message, actions = validate_property(state, task)
         self.assertTrue(result, "Optional URL prop is present and well-formed; validation should pass.")
@@ -386,10 +381,10 @@ class PropertyValidationTaskTests(unittest.TestCase):
             task_meta = active_tasks[0]
             task_func = task_named(task_meta['name'])
 
-            if task_meta['id'] == last_task_id:
+            if task_meta['task_id'] == last_task_id:
                 break
 
-            last_task_id = task_meta['id']
+            last_task_id = task_meta['task_id']
             call_task(task_func, task_meta, store)
 
         state = store.get_state()

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -45,5 +45,14 @@ class InitializationTests(unittest.TestCase):
         self.assertEqual(results.get('input').get('input_type'), 'url')
 
         self.assertEqual(
-            len([t for t in results['tasks'] if not t['success']]), 0,
+            len(results.get('messages')), 0,
             "There should be no failing tasks.")
+
+    # def debug_live_badge_verification(self):
+    #     """
+    #     Developers: Uncomment this test to run a quick verification check in your debugger.
+    #     """
+    #     results = verify(
+    #         'http://NOTAVALIDURL.COM')
+    #
+    #     self.assertTrue(results['valid'])

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -51,6 +51,8 @@ class InitializationTests(unittest.TestCase):
     # def debug_live_badge_verification(self):
     #     """
     #     Developers: Uncomment this test to run a quick verification check in your debugger.
+    #     Because this test method name doesn't start with 'test', it will not be automatically run
+    #     even when uncommented.
     #     """
     #     results = verify(
     #         'http://NOTAVALIDURL.COM')


### PR DESCRIPTION
Returns a much less verbose result, no longer just a naive dump of state. This includes the properties listed in #84.

* Also: changes task identifier property from `task['id']` to `task['task_id']` to avoid conflation with graph `id`s, which are expected to be in IRI format. Task `task_id`s are in integer format.

The app is now usable for hosted Assertions input by URL and can validate many things about them.