### PR TITLE
Feature/store canonical source from json input

### DIFF
--- a/badgecheck/reducers/input.py
+++ b/badgecheck/reducers/input.py
@@ -2,14 +2,14 @@ from ..actions.action_types import STORE_INPUT, SET_INPUT_TYPE
 
 
 def input_reducer(state=None, action=None):
-    if state is None:
-        state = {}
+    if isinstance(state, dict):
+        new_state = state.copy()
+    else:
+        new_state = {}
 
     if action.get('type') == STORE_INPUT:
-        return {'value': action.get('input')}
+        new_state.update({'value': action.get('input')})
     elif action.get('type') == SET_INPUT_TYPE:
-        new_state = state.copy()
         new_state.update({'input_type': action.get('input_type')})
-        return new_state
 
-    return state
+    return new_state

--- a/badgecheck/tasks/input.py
+++ b/badgecheck/tasks/input.py
@@ -1,9 +1,12 @@
 import json
+from pyld import jsonld
 import re
 import validators
 
-from ..actions.input import set_input_type
+from ..actions.input import set_input_type, store_input
 from ..actions.tasks import add_task
+from ..openbadges_context import OPENBADGES_CONTEXT_V2_URI
+from ..utils import CachableDocumentLoader
 from task_types import FETCH_HTTP_NODE
 from utils import task_result
 
@@ -28,6 +31,14 @@ def input_is_jws(user_input):
     return bool(jws_regex.match(user_input))
 
 
+def find_id_in_jsonld(json_string):
+    input_data = json.loads(json_string)
+    options = {'documentLoader': CachableDocumentLoader(cachable=True)}
+    result = jsonld.compact(input_data, OPENBADGES_CONTEXT_V2_URI, options=options)
+    node_id = result.get('id','')
+    return node_id
+
+
 """
 Input-processing tasks
 """
@@ -44,8 +55,15 @@ def detect_input_type(state, task_meta=None):
         new_actions.append(set_input_type(detected_type))
         new_actions.append(add_task(FETCH_HTTP_NODE, url=input_value))
     elif input_is_json(input_value):
-        detected_type = 'json'
+        id_url = find_id_in_jsonld(input_value)
+        if input_is_url(id_url):
+            detected_type = 'url'
+            new_actions.append(store_input(id_url))
+        else:
+            detected_type = 'json'
         new_actions.append(set_input_type(detected_type))
+        if detected_type == 'url':
+            new_actions.append(add_task(FETCH_HTTP_NODE, url=id_url))
     elif input_is_jws(input_value):
         detected_type = 'jws'
         new_actions.append(set_input_type(detected_type))

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,11 +1,14 @@
 import unittest
 
+import json
 from pydux import create_store
 
 from badgecheck.actions.input import set_input_type, store_input
 from badgecheck.reducers import main_reducer
 from badgecheck.state import INITIAL_STATE
 from badgecheck.tasks.input import detect_input_type
+
+from testfiles.test_components import test_components
 
 
 class InputReducerTests(unittest.TestCase):
@@ -37,4 +40,43 @@ class InputTaskTests(unittest.TestCase):
         self.assertEqual(len(actions), 2)
         self.assertEqual(actions[0]['type'], 'SET_INPUT_TYPE')
         self.assertEqual(actions[1]['url'], url)
+
+    def test_input_jsonld_type_detection_replaces_with_url(self):
+        """
+        The detect_input_type task should successfully detect JSONLD with an id URL
+        as input and switch to using an 'id' as URL value if possible
+        """
+        json_input = test_components['2_0_basic_assertion']
+        state = INITIAL_STATE.copy()
+        state['input']['value'] = json_input
+
+        success, message, actions = detect_input_type(state)
+
+        self.assertTrue(success)
+        self.assertEqual(len(actions), 3)
+        self.assertEqual(actions[0]['type'], 'STORE_INPUT')
+        self.assertEqual(actions[1]['type'], 'SET_INPUT_TYPE')
+        self.assertEqual(actions[2]['type'], 'ADD_TASK')
+        self.assertEqual(actions[2]['name'], 'FETCH_HTTP_NODE')
+
+        self.assertEqual(actions[0]['input'], actions[2]['url'])
+        self.assertEqual(json.loads(json_input)['id'], actions[2]['url'])
+
+    def test_input_jsonld_type_detection_preserves_json(self):
+        """
+        If the detect_input_type_task can't find an id field as a URL, it preserves
+        the input as json
+        """
+        assertion_dict = json.loads(test_components['2_0_basic_assertion'])
+        assertion_dict['id'] = assertion_dict['badge'] = u'urn:org:example:badges:robotics:beth'
+        json_input = json.dumps(assertion_dict)
+        state = INITIAL_STATE.copy()
+        state['input']['value'] = json_input
+
+        success, message, actions = detect_input_type(state)
+
+        self.assertTrue(success)
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0]['type'], 'SET_INPUT_TYPE')
+        self.assertEqual(actions[0]['input_type'], 'json')
 


### PR DESCRIPTION
Addresses issue #51 

- If the verifier gets JSON input form which it can get a usable ID, it should use that ID as the state's value, not the JSON input, and re-fetch the canonical source of the ID.

- Presumes that this transform only applies: (i) if the JSON input can be compacted using the open badges context, and then (ii) a top-level `id` property can be pulled, and then (ii) that property's value can be verified as a URL.

- If the JSON input doesn't satisfy these points, the detected input type remains as JSON, and the state's input value remains the provided JSON string.