### PR TITLE
Add basic Flask web server

### DIFF
--- a/badgecheck/server/app.py
+++ b/badgecheck/server/app.py
@@ -1,0 +1,30 @@
+from flask import Flask, redirect, render_template, request
+import json
+
+from badgecheck.verifier import verify
+
+from utils import validate_input
+
+app = Flask(__name__)
+
+
+
+
+@app.route("/")
+def home():
+    return render_template('index.html')
+
+
+@app.route("/results", methods=['POST'])
+def results():
+    if validate_input(request.form['data']):
+        user_input = request.form['data']
+        verification_results = verify(user_input)
+        return render_template(
+            'results.html', results=json.dumps(verification_results, indent=4))
+
+    return redirect('/')
+
+
+if __name__ == "__main__":
+    app.run()

--- a/badgecheck/server/static/screen.css
+++ b/badgecheck/server/static/screen.css
@@ -1,0 +1,58 @@
+body {
+	margin: 5%;
+	text-align: center;
+	font-family: sans-serif;
+	color:rgb(80,80,80);
+	background-color: rgb(255,255,255);
+}
+
+* {
+    box-sizing: border-box;
+/*	margin-top:5% */
+}
+
+a#logo {
+	display: block;
+	position: absolute;
+	right: 5%;
+	top: 5%;
+}
+
+h1 {
+	margin-top: 6em;
+	margin-bottom:5%;
+}
+
+#notice {
+	color: red;
+}
+
+form {
+	padding:5% 5% 5% 5%;
+}
+
+form#submit {
+	margin-top:3em;
+	text-align: left;
+	border: 1px solid rgb(190,190,190);
+}
+
+form#results textarea {
+	font-family:monospace;
+	width:80%;
+	height:auto;
+	border: 1px solid rgb(190,190,190);
+}
+
+input[type="text"] {
+    width: 80%;
+}
+
+footer {
+	font-size:80%;
+}
+
+footer p {
+	font-style:italic;
+}
+

--- a/badgecheck/server/templates/base.html
+++ b/badgecheck/server/templates/base.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8" />
+	<title>IMS Global Open Badges 2.0 Validator BETA</title>
+	<link rel="stylesheet" type="text/css" href="/static/screen.css">
+</head>
+
+<body>
+<header>
+    <a id="logo" href="https://www.imsglobal.org">
+        <img src="https://www.imsglobal.org/sites/default/files/imslogo.png" alt="IMS Global Homepage">
+    </a>
+</header>
+
+<h1>IMS Global Open Badges Validator 2.0 BETA</h1>
+
+<section id="notice">
+    <h2 >Notice</h2>
+    <p>
+        This service is currently in <strong>early beta</strong> stage. The results provided by the service cannot
+        be used as a reliable indicator of the validity of an Open Badge, and can not not be used as proof to claim
+        implementation conformance. Also read the <a href="#disclaimer">disclaimer</a> below.
+    </p>
+</section>
+
+{% block main %}{% endblock %}
+
+<footer>
+    <h2 id="disclaimer">Disclaimer</h2>
+    <p>
+        IMS Global takes no responsibility for and will not be liable for this service being temporarily unavailable
+        due to technical issues (or otherwise), or for any loss or damage suffered as a result of the use of or access
+        to, or inability to use or access this service whatsoever.
+    </p>
+</footer>
+
+</body>
+</html>

--- a/badgecheck/server/templates/index.html
+++ b/badgecheck/server/templates/index.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block main %}
+<form action="/results" method="post" id="submit">
+	<p>Paste an <a href="https://www.imsglobal.org/sites/default/files/Badges/OBv2p0/index.html">Open Badges 2.0</a> assertion URL or JSON-LD payload in the text field below and submit.</p>
+	<input type="text" id="input-name" name="data" placeholder="URL or JSON-LD">
+	<input type="submit" value="Submit" id="input-submit">
+</form>
+{% endblock %}

--- a/badgecheck/server/templates/results.html
+++ b/badgecheck/server/templates/results.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block main %}
+<p>The results returned by the validator are shown in the box below. Please report any bugs or issues to the <a href="https://github.com/openbadges/badgecheck/issues">development team</a>.</p>
+
+<form id="results">
+	<textarea id="data" rows="30">{{ results }}</textarea>
+</form>
+{% endblock %}

--- a/badgecheck/server/utils.py
+++ b/badgecheck/server/utils.py
@@ -1,0 +1,5 @@
+import six
+
+
+def validate_input(data):
+    return isinstance(data, six.string_types)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ validators==0.11.2
 # Development dependencies
 pytest
 responses==0.5.1
+
+# Server dependencies
+Flask==0.12.1

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,8 @@ setup(
         'rfc3986==0.4.1',
         'validators==0.11.2',
         # 'openbadges_bakery >= 0.1.4'  # Removing until openbadges_bakery does not require Django.
-    ]
+    ],
+    extras_require={
+        'server':  ["Flask==0.12.1"],
+    }
 )


### PR DESCRIPTION
Eventually, users who wish to install server dependencies can use `pip install openbadges_validator [server]`

Type `python badgecheck/server/app.py` from within the git root to start up the server on your local port 5000 (default Flask port).

GET "/" (see a form to post a string)
POST "/results" - see results