### PR TITLE
Feature/scrub revocation list

### DIFF
--- a/badgecheck/actions/action_types.py
+++ b/badgecheck/actions/action_types.py
@@ -12,6 +12,7 @@ Manage the state of the known entities related to the validation subject.
 """
 ADD_NODE = 'ADD_NODE'
 PATCH_NODE = 'PATCH_NODE'
+SCRUB_REVOCATION_LIST = 'SCRUB_REVOCATION_LIST'
 UPDATE_NODE = 'UPDATE_NODE'
 
 """

--- a/badgecheck/actions/graph.py
+++ b/badgecheck/actions/graph.py
@@ -1,4 +1,4 @@
-from action_types import ADD_NODE, PATCH_NODE, UPDATE_NODE
+from action_types import ADD_NODE, PATCH_NODE, SCRUB_REVOCATION_LIST, UPDATE_NODE
 
 
 def add_node(node_id=None, data=None):
@@ -13,7 +13,7 @@ def add_node(node_id=None, data=None):
 
 
 def update_node(node_id, data):
-    action ={
+    action = {
         'type': UPDATE_NODE,
         'node_id': node_id,
         'data': data
@@ -25,3 +25,13 @@ def patch_node(node_id, data):
     action = update_node(node_id, data)
     action['type'] = PATCH_NODE
     return action
+
+
+def scrub_revocation_list(node_id, safe_ids=None):
+    if safe_ids is None:
+        safe_ids = []
+    return {
+        'type': SCRUB_REVOCATION_LIST,
+        'node_id': node_id,
+        'safe_ids': safe_ids
+    }

--- a/badgecheck/reducers/graph.py
+++ b/badgecheck/reducers/graph.py
@@ -49,7 +49,7 @@ def _scrub_revocation_list_node(state, node_id, safe_ids=None):
 
     new_state = []
 
-    ids_to_exclude = [node_id] + list_of(target_node.get('revokedAssertions', []))
+    ids_to_exclude = list_of(target_node.get('revokedAssertions', []))
 
     for node in state:
         if node.get('id') in safe_ids or node.get('id') not in ids_to_exclude:

--- a/tests/test_signed_verification.py
+++ b/tests/test_signed_verification.py
@@ -133,19 +133,22 @@ class JwsVerificationTests(unittest.TestCase):
         result, message, actions = verify_signed_assertion_not_revoked(state, task_meta)
         self.assertTrue(result)
 
+        b123 = {'id': 'http://example.org/another', 'revocationReason': 'was imaginary'}
         revocation_list['revokedAssertions'] = [
             self.assertion_data['id'], 'http://example.org/else',
-            {'id': 'http://example.org/another', 'revocationReason': 'was imaginary'}
+            'http://example.org/another'
         ]
+        state['graph'].append(b123)
         result, message, actions = verify_signed_assertion_not_revoked(state, task_meta)
         self.assertFalse(result)
 
-        revocation_list['revokedAssertions'][0] = {
+        revocation_entry = {
             'id': self.assertion_data['id'],
             'revocationReason': 'Tom got to pressing the award button again. Oh, Tom.'}
+        state['graph'].append(revocation_entry)
         result, message, actions = verify_signed_assertion_not_revoked(state, task_meta)
         self.assertFalse(result)
-        self.assertIn(revocation_list['revokedAssertions'][0]['revocationReason'], message)
+        self.assertIn(revocation_entry['revocationReason'], message)
 
 
 class JwsFullVerifyTests(unittest.TestCase):
@@ -231,6 +234,59 @@ class JwsFullVerifyTests(unittest.TestCase):
 
         response = verify(signature)
         self.assertTrue(response['valid'])
+
+    @responses.activate
+    def test_revoked_badge_marked_invalid(self):
+        input_assertion = json.loads(test_components['2_0_basic_assertion'])
+        input_assertion['verification'] = {'type': 'signed', 'creator': 'http://example.org/key1'}
+
+        input_badgeclass = json.loads(test_components['2_0_basic_badgeclass'])
+
+        revocation_list = {
+            '@context': OPENBADGES_CONTEXT_V2_URI,
+            'id': 'http://example.org/revocationList',
+            'type': 'RevocationList',
+            'revokedAssertions': [
+                {'id': input_assertion['id'], 'revocationReason': 'A good reason, for sure'},
+                {'id': '52e4c6b3-8c13-4fa8-8482-a5cf34ef37a9'},
+                'urn:uuid:6deb4a00-ebce-4b28-8cc2-afa705ef7be4'
+            ]
+        }
+        input_issuer = json.loads(test_components['2_0_basic_issuer'])
+        input_issuer['revocationList'] = revocation_list['id']
+        input_issuer['publicKey'] = input_assertion['verification']['creator']
+
+        private_key = RSA.generate(2048)
+        cryptographic_key_doc = {
+            '@context': OPENBADGES_CONTEXT_V2_URI,
+            'id': input_assertion['verification']['creator'],
+            'type': 'CryptographicKey',
+            'owner': input_issuer['id'],
+            'publicKeyPem': private_key.publickey().exportKey('PEM')
+        }
+
+        setUpContextMock()
+        for doc in [input_assertion, input_badgeclass, input_issuer, cryptographic_key_doc, revocation_list]:
+            responses.add(responses.GET, doc['id'], json=doc, status=200)
+
+        header = json.dumps({'alg': 'RS256'})
+        payload = json.dumps(input_assertion)
+        signature = '.'.join([
+            b64encode(header),
+            b64encode(payload),
+            jws.sign(header, payload, private_key, is_json=True)
+        ])
+
+        response = verify(signature)
+        self.assertFalse(response['valid'])
+        msg = [a for a in response['messages'] if a.get('name') == VERIFY_SIGNED_ASSERTION_NOT_REVOKED][0]
+        self.assertIn('A good reason', msg['result'])
+
+        # Assert pruning went well to eliminate revocationlist nodes except for the revoked one
+        self.assertEqual(
+            len([i for i in response['graph'] if i.get('id') == input_assertion['id']]), 2,
+            "There is one original assertion and one graph entry from the revocationList")
+        self.assertEqual(len([i for i in response['graph'] if i.get('id') == '52e4c6b3-8c13-4fa8-8482-a5cf34ef37a9']), 0)
 
 
 class GraphScrubbingTests(unittest.TestCase):


### PR DESCRIPTION
In order to present only relevant results, we remove entries from the revocationList that aren't relevant to the current verification request from the graph before reporting back to the requester.