### PR TITLE
Breaking API change: Update validation report information to be in report key

### DIFF
--- a/badgecheck/tasks/verification.py
+++ b/badgecheck/tasks/verification.py
@@ -1,11 +1,10 @@
-import hashlib
 import rfc3986
 
 from ..actions.tasks import report_message
 from ..actions.validation_report import set_verified_recipient_profile
 from ..exceptions import TaskPrerequisitesError
 from ..state import get_node_by_id, get_node_by_path
-from ..utils import list_of
+from ..utils import identity_hash, list_of
 
 from .utils import abbreviate_value as abv, task_result
 
@@ -61,9 +60,9 @@ def hosted_id_in_verification_scope(state, task_meta):
 
 def _matches_hash(profile_identifier, id_hash, salt=''):
     if id_hash.startswith('md5'):
-        return 'md5$' + hashlib.md5(profile_identifier + salt).hexdigest() == id_hash
+        return identity_hash(profile_identifier, salt, alg='md5') == id_hash
     elif id_hash.startswith('sha256'):
-        return 'sha256$' + hashlib.sha256(profile_identifier + salt).hexdigest() == id_hash
+        return identity_hash(profile_identifier, salt, alg='sha256') == id_hash
 
     raise TypeError("Cannot interpret hash type of {}".format(id_hash))
 

--- a/badgecheck/utils.py
+++ b/badgecheck/utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import string
 from urlparse import urlparse
 
@@ -56,3 +57,11 @@ def list_of(value):
     if isinstance(value, list):
         return value
     return [value]
+
+
+def identity_hash(identfier, salt='', alg='sha256'):
+    if alg == 'sha256':
+        return alg + '$' + hashlib.sha256(identfier + salt).hexdigest()
+    elif alg == 'md5':
+        return alg + '$' + hashlib.md5(identfier + salt).hexdigest()
+    raise ValueError("Alg {} not supported.".format(alg))

--- a/badgecheck/verifier.py
+++ b/badgecheck/verifier.py
@@ -108,19 +108,20 @@ def generate_report(store, options=DEFAULT_OPTIONS):
             pass
 
     tasks_for_messages_list = filter_messages_for_report(state)
+    report = state['report'].copy()
+    report['messages'] = []
+    for task in tasks_for_messages_list:
+        report['messages'].append(format_message(task))
+
+    report['errorCount'] = len([m for m in report['messages'] if m['messageLevel'] == MESSAGE_LEVEL_ERROR])
+    report['warningCount'] = len([m for m in report['messages'] if m['messageLevel'] == MESSAGE_LEVEL_WARNING])
+    report['valid'] = not bool(report['errorCount'])
+
     ret = {
-        'messages': [],
         'graph': state['graph'],
         'input': processed_input,
-        'report': state['report']
+        'report': report
     }
-    for task in tasks_for_messages_list:
-        ret['messages'].append(format_message(task))
-
-    ret['errorCount'] = len([m for m in ret['messages'] if m['messageLevel'] == MESSAGE_LEVEL_ERROR])
-    ret['warningCount'] = len([m for m in ret['messages'] if m['messageLevel'] == MESSAGE_LEVEL_WARNING])
-    ret['valid'] = not bool(ret['errorCount'])
-
     return ret
 
 

--- a/tests/test_recipient.py
+++ b/tests/test_recipient.py
@@ -117,7 +117,7 @@ class RecipientProfileVerificationTests(unittest.TestCase):
         result, message, actions = verify_recipient_against_trusted_profile(state, task_meta)
         self.assertTrue(result)
         self.assertIn(recipient_profile['schema:duns'], message)
-        self.assertEqual(len(actions), 1)
+        self.assertEqual(len(actions), 2)
         self.assertIn('schema:duns', actions[0]['message'], "Non-standard identifier reported")
 
     def test_profile_with_multiple_emails(self):

--- a/tests/test_signed_verification.py
+++ b/tests/test_signed_verification.py
@@ -193,7 +193,7 @@ class JwsFullVerifyTests(unittest.TestCase):
         ])
 
         response = verify(signature)
-        self.assertTrue(response['valid'])
+        self.assertTrue(response['report']['valid'])
 
     @responses.activate
     def test_can_full_verify_with_revocation_check(self):
@@ -233,7 +233,7 @@ class JwsFullVerifyTests(unittest.TestCase):
         ])
 
         response = verify(signature)
-        self.assertTrue(response['valid'])
+        self.assertTrue(response['report']['valid'])
 
     @responses.activate
     def test_revoked_badge_marked_invalid(self):
@@ -278,8 +278,8 @@ class JwsFullVerifyTests(unittest.TestCase):
         ])
 
         response = verify(signature)
-        self.assertFalse(response['valid'])
-        msg = [a for a in response['messages'] if a.get('name') == VERIFY_SIGNED_ASSERTION_NOT_REVOKED][0]
+        self.assertFalse(response['report']['valid'])
+        msg = [a for a in response['report']['messages'] if a.get('name') == VERIFY_SIGNED_ASSERTION_NOT_REVOKED][0]
         self.assertIn('A good reason', msg['result'])
 
         # Assert pruning went well to eliminate revocationlist revokedAssertions except for the revoked one

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1187,7 +1187,7 @@ class BadgeClassInputValidationTests(unittest.TestCase):
         setUpContextMock()
 
         results = verify('http://example.com/badgeclass1')
-        self.assertTrue(results.get('valid'))
+        self.assertTrue(results['report']['valid'])
 
 
 class IssuerClassValidationTests(unittest.TestCase):

--- a/tests/test_verification_report.py
+++ b/tests/test_verification_report.py
@@ -54,10 +54,11 @@ class VerificationReportTests(unittest.TestCase):
     @responses.activate
     def test_confirmed_recipient_profile_reported(self):
         url = 'https://example.org/beths-robotics-badge.json'
+        email = 'nobody@example.org'
         self.set_response_mocks()
-        store = verification_store(url, recipient_profile={'email': 'test@example.com'})
+        store = verification_store(url, recipient_profile={'email': email})
         report = generate_report(store)
-        self.assertEqual(report['report']['recipientProfile']['email'], 'test@example.com')
+        self.assertEqual(report['report']['recipientProfile']['email'], email)
 
     def test_validation_version(self):
         """

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -51,8 +51,7 @@ class InitializationTests(unittest.TestCase):
         self.assertEqual(results.get('input').get('input_type'), 'url')
 
         self.assertEqual(
-            len(results.get('messages')), 0,
-            "There should be no failing tasks.")
+            len(results['report']['messages']), 0, "There should be no failing tasks.")
 
     @responses.activate
     def test_verify_of_baked_image(self):
@@ -88,8 +87,7 @@ class InitializationTests(unittest.TestCase):
         self.assertNotEqual(results, None)
         self.assertEqual(results.get('input').get('value'), url)
         self.assertEqual(results.get('input').get('input_type'), 'url')
-        self.assertEqual(len(results.get('messages')), 0,
-                         "There should be no failing tasks.")
+        self.assertEqual(len(results['report']['messages']), 0, "There should be no failing tasks.")
 
     # def debug_live_badge_verification(self):
     #     """
@@ -111,9 +109,9 @@ class MessagesTests(unittest.TestCase):
         state = store.get_state()
         self.assertEqual(len(state['tasks']), 1)
 
-        report = generate_report(store)
-        self.assertEqual(len(report['messages']), 1)
-        self.assertEqual(report['messages'][0]['result'], 'TEST MESSAGE')
+        result = generate_report(store)
+        self.assertEqual(len(result['report']['messages']), 1)
+        self.assertEqual(result['report']['messages'][0]['result'], 'TEST MESSAGE')
 
 
 class ResultReportTests(unittest.TestCase):

--- a/tests/testfiles/test_components.py
+++ b/tests/testfiles/test_components.py
@@ -71,7 +71,7 @@ test_components = {
     "type": "email",
     "hashed": true,
     "salt": "deadsea",
-    "identity": "sha256$c7ef86405ba71b85acd8e2e95166c4b111448089f2e1599f42fe1bba46e865c5"
+    "identity": "sha256$ecf5409f3f4b91ab60cc5ef4c02aef7032354375e70cf4d8e43f6a1d29891942"
   },
   "image": "https://example.org/beths-robot-badge.png",
   "evidence": "https://example.org/beths-robot-work.html",


### PR DESCRIPTION
Breaking API change: Update validation report information to be in report key of the response object. This object identifies the subject node of validation, whether it is valid, error counts, messages, and if an assertion where recipient_profile is used, the confirmed identity of the recipient.
```json
"report": {
        "validationSubject": "https://api.badgr.io/public/assertions/1c6de3ea-b91e-4ce8-b735-ca9504faafe5", 
        "valid": true, 
        "messages": [], 
        "errorCount": 0, 
        "warningCount": 0
    } 
```

With recipient_profile:
```json
"report": {
        "validationSubject": "https://api.badgr.io/share/badge/e5f0c5f1-efb2-4ecb-90d4-cf7fc8131e5e?v=2_0", 
        "valid": true, 
        "messages": [], 
        "errorCount": 0, 
        "warningCount": 0,
        "recipientProfile": {"email": "notto@concentricsky.com"}
    } 
```

Previously, `validationSubject` and `recipientProfile` did not exist, and `valid`, `messages`, `errorCount` and `warningCount` were top-level properties of the API response.