### PR TITLE
Allow python client to pass in requests_cache backend

### DIFF
--- a/badgecheck/tasks/crypto.py
+++ b/badgecheck/tasks/crypto.py
@@ -17,7 +17,7 @@ from .task_types import (ISSUER_PROPERTY_DEPENDENCIES, JSONLD_COMPACT_DATA, SIGN
 from .validation import OBClasses, ValueTypes
 
 
-def process_jws_input(state, task_meta):
+def process_jws_input(state, task_meta, **options):
     try:
         data = task_meta['data']
     except KeyError:
@@ -38,7 +38,7 @@ def process_jws_input(state, task_meta):
     return task_result(True, "Processed JWS-signed data and queued signature verification task", actions)
 
 
-def verify_jws_signature(state, task_meta):
+def verify_jws_signature(state, task_meta, **options):
     try:
         data = task_meta['data']
         node_id = task_meta['node_id']
@@ -74,7 +74,7 @@ def verify_jws_signature(state, task_meta):
         True, "Signature for node {} passed verification".format(node_id), actions)
 
 
-def verify_key_ownership(state, task_meta):
+def verify_key_ownership(state, task_meta, **options):
     try:
         node_id = task_meta['node_id']
         issuer_node = get_node_by_path(state, [node_id, 'badge', 'issuer'])
@@ -100,7 +100,7 @@ def verify_key_ownership(state, task_meta):
         True, "Assertion signing key {} is properly declared in issuer profile".format(key_id), actions)
 
 
-def verify_signed_assertion_not_revoked(state, task_meta):
+def verify_signed_assertion_not_revoked(state, task_meta, **options):
     try:
         assertion_id = task_meta['node_id']
         issuer = get_node_by_path(state, [assertion_id, 'badge', 'issuer'])

--- a/badgecheck/tasks/graph.py
+++ b/badgecheck/tasks/graph.py
@@ -8,7 +8,7 @@ from ..actions.tasks import add_task
 from ..exceptions import TaskPrerequisitesError, ValidationError
 from ..openbadges_context import OPENBADGES_CONTEXT_V2_URI
 from ..reducers.graph import get_next_blank_node_id
-from ..utils import CachableDocumentLoader, list_of
+from ..utils import CachableDocumentLoader, list_of, jsonld_use_cache
 
 from .task_types import (DETECT_AND_VALIDATE_NODE_CLASS, JSONLD_COMPACT_DATA,
                         VALIDATE_EXPECTED_NODE_CLASS, VALIDATE_EXTENSION_NODE,)
@@ -68,8 +68,8 @@ def jsonld_compact_data(state, task_meta):
     except TypeError:
         return task_result(False, "Could not load data")
 
-    options = {'documentLoader': CachableDocumentLoader(cachable=task_meta.get('use_cache', True))}
-    result = jsonld.compact(input_data, OPENBADGES_CONTEXT_V2_URI, options=options)
+    #options = {'documentLoader': CachableDocumentLoader(cachable=task_meta.get('use_cache', True))}
+    result = jsonld.compact(input_data, OPENBADGES_CONTEXT_V2_URI, options=jsonld_use_cache)
     node_id = result.get('id', task_meta.get('node_id', get_next_blank_node_id()))
 
     actions = [

--- a/badgecheck/tasks/graph.py
+++ b/badgecheck/tasks/graph.py
@@ -1,6 +1,7 @@
 import json
 from pyld import jsonld
 import requests
+import requests_cache
 
 from ..actions.graph import add_node
 from ..actions.input import store_original_json
@@ -15,10 +16,16 @@ from .task_types import (DETECT_AND_VALIDATE_NODE_CLASS, JSONLD_COMPACT_DATA,
 from .utils import filter_tasks, task_result, is_iri
 
 
-def fetch_http_node(state, task_meta):
+def fetch_http_node(state, task_meta, **options):
     url = task_meta['url']
 
-    result = requests.get(
+    if options.get('cache_backend'):
+        session = requests_cache.CachedSession(
+            backend=options['cache_backend'], expire_after=options.get('cache_expire_after', 300))
+    else:
+        session = requests.Session()
+
+    result = session.get(
         url, headers={'Accept': 'application/ld+json, application/json, image/png, image/svg+xml'}
     )
 
@@ -62,14 +69,14 @@ def _get_extension_actions(current_node, entry_path):
     return new_actions
 
 
-def jsonld_compact_data(state, task_meta):
+def jsonld_compact_data(state, task_meta, **options):
     try:
         input_data = json.loads(task_meta.get('data'))
     except TypeError:
         return task_result(False, "Could not load data")
 
-    #options = {'documentLoader': CachableDocumentLoader(cachable=task_meta.get('use_cache', True))}
-    result = jsonld.compact(input_data, OPENBADGES_CONTEXT_V2_URI, options=jsonld_use_cache)
+    result = jsonld.compact(input_data, OPENBADGES_CONTEXT_V2_URI,
+                            options=options.get('jsonld_options', jsonld_use_cache))
     node_id = result.get('id', task_meta.get('node_id', get_next_blank_node_id()))
 
     actions = [

--- a/badgecheck/tasks/input.py
+++ b/badgecheck/tasks/input.py
@@ -7,7 +7,7 @@ from ..actions.input import set_input_type, store_input
 from ..actions.tasks import add_task
 from ..actions.validation_report import set_validation_subject
 from ..openbadges_context import OPENBADGES_CONTEXT_V2_URI
-from ..utils import CachableDocumentLoader
+from ..utils import CachableDocumentLoader, jsonld_use_cache
 from task_types import FETCH_HTTP_NODE, PROCESS_JWS_INPUT
 from utils import task_result
 
@@ -34,8 +34,8 @@ def input_is_jws(user_input):
 
 def find_id_in_jsonld(json_string):
     input_data = json.loads(json_string)
-    options = {'documentLoader': CachableDocumentLoader(cachable=True)}
-    result = jsonld.compact(input_data, OPENBADGES_CONTEXT_V2_URI, options=options)
+    # options = {'documentLoader': CachableDocumentLoader(cachable=True)}
+    result = jsonld.compact(input_data, OPENBADGES_CONTEXT_V2_URI, options=jsonld_use_cache)
     node_id = result.get('id','')
     return node_id
 

--- a/badgecheck/tasks/input.py
+++ b/badgecheck/tasks/input.py
@@ -32,10 +32,9 @@ def input_is_jws(user_input):
     return bool(jws_regex.match(user_input))
 
 
-def find_id_in_jsonld(json_string):
+def find_id_in_jsonld(json_string, jsonld_options):
     input_data = json.loads(json_string)
-    # options = {'documentLoader': CachableDocumentLoader(cachable=True)}
-    result = jsonld.compact(input_data, OPENBADGES_CONTEXT_V2_URI, options=jsonld_use_cache)
+    result = jsonld.compact(input_data, OPENBADGES_CONTEXT_V2_URI, options=jsonld_options)
     node_id = result.get('id','')
     return node_id
 
@@ -43,7 +42,7 @@ def find_id_in_jsonld(json_string):
 """
 Input-processing tasks
 """
-def detect_input_type(state, task_meta=None):
+def detect_input_type(state, task_meta=None, **options):
     """
     Detects what data format user has provided and saves to the store.
     """
@@ -57,7 +56,7 @@ def detect_input_type(state, task_meta=None):
         new_actions.append(add_task(FETCH_HTTP_NODE, url=input_value))
         new_actions.append(set_validation_subject(input_value))
     elif input_is_json(input_value):
-        id_url = find_id_in_jsonld(input_value)
+        id_url = find_id_in_jsonld(input_value, options.get('jsonld_options', jsonld_use_cache))
         if input_is_url(id_url):
             detected_type = 'url'
             new_actions.append(store_input(id_url))

--- a/badgecheck/tasks/validation.py
+++ b/badgecheck/tasks/validation.py
@@ -198,7 +198,7 @@ class PrimitiveValueValidator(object):
         return is_url(value)
 
 
-def validate_property(state, task_meta):
+def validate_property(state, task_meta, **options):
     """
     Validates presence and data type of a single property that is
     expected to be one of the Open Badges Primitive data types or an ID.
@@ -299,7 +299,7 @@ def validate_property(state, task_meta):
     )
 
 
-def validate_rdf_type_property(state, task_meta):
+def validate_rdf_type_property(state, task_meta, **options):
     prop_result = validate_property(state, task_meta)
     if not prop_result[0]:
         return prop_result
@@ -515,7 +515,7 @@ def _get_validation_actions(node_class, node_id=None, node_path=None):
     return actions
 
 
-def detect_and_validate_node_class(state, task_meta):
+def detect_and_validate_node_class(state, task_meta, **options):
     node_id = task_meta.get('node_id')
     node_path = task_meta.get('node_path')
 
@@ -540,7 +540,7 @@ def detect_and_validate_node_class(state, task_meta):
     )
 
 
-def validate_expected_node_class(state, task_meta):
+def validate_expected_node_class(state, task_meta, **options):
     node_id = task_meta.get('node_id')
     node_path = task_meta.get('node_path')
 
@@ -557,7 +557,7 @@ def validate_expected_node_class(state, task_meta):
 """
 Class Validation Tasks
 """
-def identity_object_property_dependencies(state, task_meta):
+def identity_object_property_dependencies(state, task_meta, **options):
     node_id = task_meta.get('node_id')
     node_path = task_meta.get('node_path')
     if node_id:
@@ -585,7 +585,7 @@ def identity_object_property_dependencies(state, task_meta):
     return task_result(True, "IdentityObject passes validation rules.")
 
 
-def criteria_property_dependencies(state, task_meta):
+def criteria_property_dependencies(state, task_meta, **options):
     node_id = task_meta.get('node_id')
     node = get_node_by_id(state, node_id)
     is_blank_id_node = bool(re.match(r'_:b\d+$', node_id))
@@ -607,7 +607,7 @@ def criteria_property_dependencies(state, task_meta):
     return task_result(True, "Criteria node {} has a URL.")
 
 
-def assertion_verification_dependencies(state, task_meta):
+def assertion_verification_dependencies(state, task_meta, **options):
     """
     Performs and/or queues some security checks for hosted assertions.
     """
@@ -638,7 +638,7 @@ def assertion_verification_dependencies(state, task_meta):
     )
 
 
-def assertion_timestamp_checks(state, task_meta):
+def assertion_timestamp_checks(state, task_meta, **options):
     try:
         node_id = task_meta['node_id']
         assertion = get_node_by_id(state, node_id)
@@ -666,11 +666,11 @@ def assertion_timestamp_checks(state, task_meta):
         True, "Assertion {} was issued and has not expired.".format(node_id))
 
 
-def placeholder_task(state, task_meta):
+def placeholder_task(state, task_meta, **options):
     return task_result(True, "Placeholder (prerequisite) task complete.")
 
 
-def validate_revocationlist_entries(state, task_meta):
+def validate_revocationlist_entries(state, task_meta, **options):
     try:
         node_id = task_meta['node_id']
         revocation_list = get_node_by_id(state, node_id)

--- a/badgecheck/tasks/verification.py
+++ b/badgecheck/tasks/verification.py
@@ -1,11 +1,10 @@
-import hashlib
 import rfc3986
 
 from ..actions.tasks import report_message
 from ..actions.validation_report import set_verified_recipient_profile
 from ..exceptions import TaskPrerequisitesError
 from ..state import get_node_by_id, get_node_by_path
-from ..utils import list_of
+from ..utils import identity_hash, list_of
 
 from .utils import abbreviate_value as abv, task_result
 
@@ -61,9 +60,9 @@ def hosted_id_in_verification_scope(state, task_meta, **options):
 
 def _matches_hash(profile_identifier, id_hash, salt=''):
     if id_hash.startswith('md5'):
-        return 'md5$' + hashlib.md5(profile_identifier + salt).hexdigest() == id_hash
+        return identity_hash(profile_identifier, salt, alg='md5') == id_hash
     elif id_hash.startswith('sha256'):
-        return 'sha256$' + hashlib.sha256(profile_identifier + salt).hexdigest() == id_hash
+        return identity_hash(profile_identifier, salt, alg='sha256') == id_hash
 
     raise TypeError("Cannot interpret hash type of {}".format(id_hash))
 

--- a/badgecheck/tasks/verification.py
+++ b/badgecheck/tasks/verification.py
@@ -23,7 +23,7 @@ def _default_verification_policy(issuer_node):
     }
 
 
-def hosted_id_in_verification_scope(state, task_meta):
+def hosted_id_in_verification_scope(state, task_meta, **options):
     assertion_id = task_meta.get('node_id')
     assertion_node = get_node_by_id(state, assertion_id)
 
@@ -68,7 +68,7 @@ def _matches_hash(profile_identifier, id_hash, salt=''):
     raise TypeError("Cannot interpret hash type of {}".format(id_hash))
 
 
-def verify_recipient_against_trusted_profile(state, task_meta):
+def verify_recipient_against_trusted_profile(state, task_meta, **options):
     try:
         # Use the ID of the first Assertion found in current state
         assertion_id = [n for n in state['graph'] if n.get('type') == 'Assertion'][0]['id']

--- a/badgecheck/utils.py
+++ b/badgecheck/utils.py
@@ -7,10 +7,10 @@ from pyld.jsonld import JsonLdError
 
 
 class CachableDocumentLoader(object):
-    def __init__(self, cachable=False):
-        self.cachable = cachable
-        if self.cachable:
-            self.session = requests_cache.CachedSession(backend='memory', expire_after=300)
+    def __init__(self, use_cache=False, backend='memory', expire_after=300):
+        self.use_cache = use_cache
+        if self.use_cache:
+            self.session = requests_cache.CachedSession(backend=backend, expire_after=expire_after)
         else:
             self.session = requests.Session()
 
@@ -32,7 +32,7 @@ class CachableDocumentLoader(object):
 
             doc = {'contextUrl': None, 'documentUrl': url, 'document': response.text}
 
-            if self.cachable:
+            if self.use_cache:
                 doc['from_cache'] = response.from_cache
                 self.session.remove_expired_responses()
 
@@ -48,8 +48,8 @@ class CachableDocumentLoader(object):
                 cause=cause)
 
 
-jsonld_use_cache = {'documentLoader': CachableDocumentLoader(cachable=True)}
-jsonld_no_cache = {'documentLoader': CachableDocumentLoader(cachable=False)}
+jsonld_use_cache = {'documentLoader': CachableDocumentLoader(use_cache=True)}
+jsonld_no_cache = {'documentLoader': CachableDocumentLoader(use_cache=False)}
 
 
 def list_of(value):

--- a/badgecheck/utils.py
+++ b/badgecheck/utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import string
 from urlparse import urlparse
 
@@ -56,3 +57,11 @@ def list_of(value):
     if isinstance(value, list):
         return value
     return [value]
+
+
+def identity_hash(identfier, salt='', alg='sha256'):
+    if alg == 'sha256':
+        return alg + '$' + hashlib.sha256(identfier + salt).hexdigest()
+    elif alg == 'md5':
+        return alg + '$' + hashlib.md5(identfier + salt).hexdigest()
+    raise ValueError("Alg {} not supported.".format(alg))

--- a/badgecheck/verifier.py
+++ b/badgecheck/verifier.py
@@ -132,19 +132,20 @@ def generate_report(store, options=DEFAULT_OPTIONS):
             pass
 
     tasks_for_messages_list = filter_messages_for_report(state)
+    report = state['report'].copy()
+    report['messages'] = []
+    for task in tasks_for_messages_list:
+        report['messages'].append(format_message(task))
+
+    report['errorCount'] = len([m for m in report['messages'] if m['messageLevel'] == MESSAGE_LEVEL_ERROR])
+    report['warningCount'] = len([m for m in report['messages'] if m['messageLevel'] == MESSAGE_LEVEL_WARNING])
+    report['valid'] = not bool(report['errorCount'])
+
     ret = {
-        'messages': [],
         'graph': state['graph'],
         'input': processed_input,
-        'report': state['report']
+        'report': report
     }
-    for task in tasks_for_messages_list:
-        ret['messages'].append(format_message(task))
-
-    ret['errorCount'] = len([m for m in ret['messages'] if m['messageLevel'] == MESSAGE_LEVEL_ERROR])
-    ret['warningCount'] = len([m for m in ret['messages'] if m['messageLevel'] == MESSAGE_LEVEL_WARNING])
-    ret['valid'] = not bool(ret['errorCount'])
-
     return ret
 
 

--- a/badgecheck/verifier.py
+++ b/badgecheck/verifier.py
@@ -12,10 +12,39 @@ from .state import (filter_active_tasks, filter_messages_for_report, format_mess
 import tasks
 from tasks.task_types import JSONLD_COMPACT_DATA
 from tasks.validation import OBClasses
-from .utils import list_of
+from .utils import list_of, CachableDocumentLoader, jsonld_use_cache
 
 
-def call_task(task_func, task_meta, store):
+DEFAULT_OPTIONS = {
+    'include_original_json': False,  # Return the original JSON strings fetched from HTTP
+    'use_cache': True,
+    'cache_backend': 'memory',
+    'cache_expire_after': 300,
+    'jsonld_options': jsonld_use_cache
+}
+
+
+def _get_options(options):
+    if options:
+        selected = DEFAULT_OPTIONS.copy()
+        selected.update(options)
+    else:
+        selected = DEFAULT_OPTIONS
+
+    if selected['use_cache']:
+        doc_loader = CachableDocumentLoader(
+            use_cache=selected['use_cache'],
+            backend=selected['cache_backend'],
+            expire_after=selected['cache_expire_after']
+        )
+    else:
+        doc_loader = CachableDocumentLoader(use_cache=False)
+
+    selected['jsonld_options'] = {'documentLoader': doc_loader}
+    return selected
+
+
+def call_task(task_func, task_meta, store, options=DEFAULT_OPTIONS):
     """
     Calls and resolves a task function in response to a queued task. May result
     in additional actions added to the queue.
@@ -26,7 +55,7 @@ def call_task(task_func, task_meta, store):
     """
     actions = []
     try:
-        success, message, actions = task_func(store.get_state(), task_meta)
+        success, message, actions = task_func(store.get_state(), task_meta, **options)
     except SkipTask:
         raise NotImplemented("Implement SkipTask handling in call_task")
     except TaskPrerequisitesError:
@@ -48,7 +77,7 @@ def call_task(task_func, task_meta, store):
         store.dispatch(action)
 
 
-def verification_store(badge_input, recipient_profile=None, store=None):
+def verification_store(badge_input, recipient_profile=None, store=None, options=DEFAULT_OPTIONS):
     if store is None:
         store = create_store(main_reducer, INITIAL_STATE)
 
@@ -84,14 +113,9 @@ def verification_store(badge_input, recipient_profile=None, store=None):
             break
 
         last_task_id = task_meta['task_id']
-        call_task(task_func, task_meta, store)
+        call_task(task_func, task_meta, store, options)
 
     return store
-
-
-DEFAULT_OPTIONS = {
-    'include_original_json': False  # Return the original JSON strings fetched from HTTP
-}
 
 
 def generate_report(store, options=DEFAULT_OPTIONS):
@@ -124,7 +148,7 @@ def generate_report(store, options=DEFAULT_OPTIONS):
     return ret
 
 
-def verify(badge_input, recipient_profile=None, options=None):
+def verify(badge_input, recipient_profile=None, **options):
     """
     Verify and validate Open Badges
     :param badge_input: str (url or json) or python file-like object (baked badge image)
@@ -132,12 +156,6 @@ def verify(badge_input, recipient_profile=None, options=None):
     :param options: dict of options. See DEFAULT_OPTIONS for values
     :return: dict
     """
-    if options:
-        selected_options = DEFAULT_OPTIONS.copy()
-        selected_options.update(options)
-    else:
-        selected_options = DEFAULT_OPTIONS
-
-    store = verification_store(badge_input, recipient_profile)
-
-    return generate_report(store, selected_options)
+    selected_options = _get_options(options)
+    store = verification_store(badge_input, recipient_profile, options=selected_options)
+    return generate_report(store, options=selected_options)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -13,7 +13,7 @@ class DocumentLoaderTests(unittest.TestCase):
     @responses.activate
     def test_that_caching_loader_uses_local_cache(self):
         url = 'http://example.com/assertionmaybe'
-        loadurl = CachableDocumentLoader(cachable=True)
+        loadurl = CachableDocumentLoader(use_cache=True)
         data = test_components['2_0_basic_assertion']
         responses.add(
             responses.GET, url, body=data, status=200, content_type='application/ld+json')
@@ -30,7 +30,7 @@ class DocumentLoaderTests(unittest.TestCase):
     @responses.activate
     def test_that_noncaching_loader_loads_url(self):
         url = 'http://example.com/assertionmaybe'
-        loadurl = CachableDocumentLoader(cachable=False)
+        loadurl = CachableDocumentLoader(use_cache=False)
         data = test_components['2_0_basic_assertion']
         responses.add(
             responses.GET, url, body=data, status=200, content_type='application/ld+json')
@@ -44,7 +44,7 @@ class DocumentLoaderTests(unittest.TestCase):
     def test_that_pyld_accepts_caching_loader_for_compaction(self):
         assertion_data = json.loads(test_components['2_0_basic_assertion'])
         context_url = assertion_data['@context']
-        loadurl = CachableDocumentLoader(cachable=True)
+        loadurl = CachableDocumentLoader(use_cache=True)
         setUpContextMock()
 
         first_compacted = jsonld.compact(

--- a/tests/test_recipient.py
+++ b/tests/test_recipient.py
@@ -117,7 +117,7 @@ class RecipientProfileVerificationTests(unittest.TestCase):
         result, message, actions = verify_recipient_against_trusted_profile(state, task_meta)
         self.assertTrue(result)
         self.assertIn(recipient_profile['schema:duns'], message)
-        self.assertEqual(len(actions), 1)
+        self.assertEqual(len(actions), 2)
         self.assertIn('schema:duns', actions[0]['message'], "Non-standard identifier reported")
 
     def test_profile_with_multiple_emails(self):

--- a/tests/test_signed_verification.py
+++ b/tests/test_signed_verification.py
@@ -192,7 +192,7 @@ class JwsFullVerifyTests(unittest.TestCase):
             jws.sign(header, payload, private_key, is_json=True)
         ])
 
-        response = verify(signature)
+        response = verify(signature, use_cache=False)
         self.assertTrue(response['valid'])
 
     @responses.activate
@@ -232,7 +232,7 @@ class JwsFullVerifyTests(unittest.TestCase):
             jws.sign(header, payload, private_key, is_json=True)
         ])
 
-        response = verify(signature)
+        response = verify(signature, use_cache=False)
         self.assertTrue(response['valid'])
 
     @responses.activate
@@ -277,7 +277,7 @@ class JwsFullVerifyTests(unittest.TestCase):
             jws.sign(header, payload, private_key, is_json=True)
         ])
 
-        response = verify(signature)
+        response = verify(signature, use_cache=False)
         self.assertFalse(response['valid'])
         msg = [a for a in response['messages'] if a.get('name') == VERIFY_SIGNED_ASSERTION_NOT_REVOKED][0]
         self.assertIn('A good reason', msg['result'])

--- a/tests/test_signed_verification.py
+++ b/tests/test_signed_verification.py
@@ -193,7 +193,7 @@ class JwsFullVerifyTests(unittest.TestCase):
         ])
 
         response = verify(signature, use_cache=False)
-        self.assertTrue(response['valid'])
+        self.assertTrue(response['report']['valid'])
 
     @responses.activate
     def test_can_full_verify_with_revocation_check(self):
@@ -233,7 +233,7 @@ class JwsFullVerifyTests(unittest.TestCase):
         ])
 
         response = verify(signature, use_cache=False)
-        self.assertTrue(response['valid'])
+        self.assertTrue(response['report']['valid'])
 
     @responses.activate
     def test_revoked_badge_marked_invalid(self):
@@ -278,8 +278,8 @@ class JwsFullVerifyTests(unittest.TestCase):
         ])
 
         response = verify(signature, use_cache=False)
-        self.assertFalse(response['valid'])
-        msg = [a for a in response['messages'] if a.get('name') == VERIFY_SIGNED_ASSERTION_NOT_REVOKED][0]
+        self.assertFalse(response['report']['valid'])
+        msg = [a for a in response['report']['messages'] if a.get('name') == VERIFY_SIGNED_ASSERTION_NOT_REVOKED][0]
         self.assertIn('A good reason', msg['result'])
 
         # Assert pruning went well to eliminate revocationlist revokedAssertions except for the revoked one

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1187,7 +1187,7 @@ class BadgeClassInputValidationTests(unittest.TestCase):
         setUpContextMock()
 
         results = verify('http://example.com/badgeclass1')
-        self.assertTrue(results.get('valid'))
+        self.assertTrue(results['report']['valid'])
 
 
 class IssuerClassValidationTests(unittest.TestCase):

--- a/tests/test_verification_report.py
+++ b/tests/test_verification_report.py
@@ -54,10 +54,11 @@ class VerificationReportTests(unittest.TestCase):
     @responses.activate
     def test_confirmed_recipient_profile_reported(self):
         url = 'https://example.org/beths-robotics-badge.json'
+        email = 'nobody@example.org'
         self.set_response_mocks()
-        store = verification_store(url, recipient_profile={'email': 'test@example.com'})
+        store = verification_store(url, recipient_profile={'email': email})
         report = generate_report(store)
-        self.assertEqual(report['report']['recipientProfile']['email'], 'test@example.com')
+        self.assertEqual(report['report']['recipientProfile']['email'], email)
 
     def test_validation_version(self):
         """

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -51,8 +51,7 @@ class InitializationTests(unittest.TestCase):
         self.assertEqual(results.get('input').get('input_type'), 'url')
 
         self.assertEqual(
-            len(results.get('messages')), 0,
-            "There should be no failing tasks.")
+            len(results['report']['messages']), 0, "There should be no failing tasks.")
 
     @responses.activate
     def test_verify_of_baked_image(self):
@@ -88,8 +87,7 @@ class InitializationTests(unittest.TestCase):
         self.assertNotEqual(results, None)
         self.assertEqual(results.get('input').get('value'), url)
         self.assertEqual(results.get('input').get('input_type'), 'url')
-        self.assertEqual(len(results.get('messages')), 0,
-                         "There should be no failing tasks.")
+        self.assertEqual(len(results['report']['messages']), 0, "There should be no failing tasks.")
 
     # def debug_live_badge_verification(self):
     #     """
@@ -111,9 +109,9 @@ class MessagesTests(unittest.TestCase):
         state = store.get_state()
         self.assertEqual(len(state['tasks']), 1)
 
-        report = generate_report(store)
-        self.assertEqual(len(report['messages']), 1)
-        self.assertEqual(report['messages'][0]['result'], 'TEST MESSAGE')
+        result = generate_report(store)
+        self.assertEqual(len(result['report']['messages']), 1)
+        self.assertEqual(result['report']['messages'][0]['result'], 'TEST MESSAGE')
 
 
 class ResultReportTests(unittest.TestCase):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -150,7 +150,7 @@ class ResultReportTests(unittest.TestCase):
             content_type='application/ld+json'
         )
 
-        result = verify(url, options={'include_original_json': True})
+        result = verify(url, include_original_json=True)
         self.assertIn('original_json', result['input'].keys())
         self.assertEqual(len(result['input']['original_json']), 3)
         self.assertIn(url, result['input']['original_json'].keys())

--- a/tests/testfiles/test_components.py
+++ b/tests/testfiles/test_components.py
@@ -71,7 +71,7 @@ test_components = {
     "type": "email",
     "hashed": true,
     "salt": "deadsea",
-    "identity": "sha256$c7ef86405ba71b85acd8e2e95166c4b111448089f2e1599f42fe1bba46e865c5"
+    "identity": "sha256$ecf5409f3f4b91ab60cc5ef4c02aef7032354375e70cf4d8e43f6a1d29891942"
   },
   "image": "https://example.org/beths-robot-badge.png",
   "evidence": "https://example.org/beths-robot-work.html",


### PR DESCRIPTION
Use `verify(badge_input, cache_backend=MyBackend())` to pass in your own backend for requests-cache if you are using one elsewhere in your application or wrapper for badgecheck.

See [requests-cache docs](http://requests-cache.readthedocs.io/en/latest/index.html)

Merge #140 first for a cleaner changelog.

* This allows an options dict to be passed in as **kwargs to all the task functions. The ones that use requests or jsonld to potentially make HTTP requests will look in this options set for appropriate options.
* When you pass in kwargs to verify(), these are added to the default options, and a 
* By default, the same doc cache is used for all jsonld requests within a session. A new memory-based cache is used for each new verify() request.
* Implementers who wish to use this library in production are encouraged to configure and 

Further improvements to the micro server app will take better advantage of the caching features. This PR is mostly aimed at implementers who will be using the library for high-volume requests.