### PR TITLE
Email and telephone string validators

### DIFF
--- a/badgecheck/tasks/validation.py
+++ b/badgecheck/tasks/validation.py
@@ -73,10 +73,11 @@ class ValueTypes(object):
     IRI = 'IRI'
     MARKDOWN_TEXT = 'MARKDOWN_TEXT'
     RDF_TYPE = 'RDF_TYPE'
+    TELEPHONE = 'TELEPHONE'
     TEXT = 'TEXT'
     URL = 'URL'
 
-    PRIMITIVES = (BOOLEAN, DATETIME, ID, IDENTITY_HASH, IRI, MARKDOWN_TEXT, TEXT, URL)
+    PRIMITIVES = (BOOLEAN, DATETIME, ID, IDENTITY_HASH, IRI, MARKDOWN_TEXT, TELEPHONE, TEXT, URL)
 
 
 class PrimitiveValueValidator(object):
@@ -93,10 +94,12 @@ class PrimitiveValueValidator(object):
             ValueTypes.DATA_URI: self._validate_data_uri,
             ValueTypes.DATA_URI_OR_URL: self._validate_data_uri_or_url,
             ValueTypes.DATETIME: self._validate_datetime,
+            ValueTypes.EMAIL: self._validate_email,
             ValueTypes.IDENTITY_HASH: self._validate_identity_hash,
             ValueTypes.IRI: self._validate_iri,
             ValueTypes.MARKDOWN_TEXT: self._validate_markdown_text,
             ValueTypes.RDF_TYPE: self._validate_rdf_type,
+            ValueTypes.TELEPHONE: self._validate_tel,
             ValueTypes.TEXT: self._validate_text,
             ValueTypes.URL: self._validate_url
         }
@@ -144,7 +147,7 @@ class PrimitiveValueValidator(object):
 
     @staticmethod
     def _validate_email(value):
-        return bool(re.match(r'(^[^@]+@[^@]+$)', value))
+        return bool(re.match(r'(^[^@\s]+@[^@\s]+$)', value))
 
     @staticmethod
     def is_hashed_identity_hash(value):
@@ -188,6 +191,11 @@ class PrimitiveValueValidator(object):
             return False
 
         return True
+
+    @staticmethod
+    def _validate_tel(value):
+        """ Validates whether item passes E.164 validation (allows extensions)"""
+        return bool(re.match(r'^\+?[1-9]\d{1,14}(;ext=\d+)?$', value))
 
     @staticmethod
     def _validate_text(value):
@@ -395,8 +403,8 @@ class ClassValidators(OBClasses):
                 {'prop_name': 'description', 'prop_type': ValueTypes.TEXT, 'required': False},
                 {'prop_name': 'image', 'prop_type': ValueTypes.DATA_URI_OR_URL, 'required': False},
                 {'prop_name': 'url', 'prop_type': ValueTypes.URL, 'required': True},
-                {'prop_name': 'email', 'prop_type': ValueTypes.TEXT, 'required': True},
-                {'prop_name': 'telephone', 'prop_type': ValueTypes.TEXT, 'required': False},
+                {'prop_name': 'email', 'prop_type': ValueTypes.EMAIL, 'required': True},
+                {'prop_name': 'telephone', 'prop_type': ValueTypes.TELEPHONE, 'required': False},
                 {'prop_name': 'publicKey', 'prop_type': ValueTypes.ID,
                     'expected_class': OBClasses.CryptographicKey, 'fetch': True, 'required': False},
                 {'prop_name': 'verification', 'prop_type': ValueTypes.ID,
@@ -413,8 +421,8 @@ class ClassValidators(OBClasses):
                 {'prop_name': 'description', 'prop_type': ValueTypes.TEXT, 'required': False},
                 {'prop_name': 'image', 'prop_type': ValueTypes.DATA_URI_OR_URL, 'required': False},
                 {'prop_name': 'url', 'prop_type': ValueTypes.URL, 'required': False, 'many': True},
-                {'prop_name': 'email', 'prop_type': ValueTypes.TEXT, 'required': False, 'many': True},
-                {'prop_name': 'telephone', 'prop_type': ValueTypes.TEXT, 'required': False, 'many': True},
+                {'prop_name': 'email', 'prop_type': ValueTypes.EMAIL, 'required': False, 'many': True},
+                {'prop_name': 'telephone', 'prop_type': ValueTypes.TELEPHONE, 'required': False, 'many': True},
                 {'prop_name': 'publicKey', 'prop_type': ValueTypes.ID, 'many': True,
                    'expected_class': OBClasses.CryptographicKey, 'fetch': False, 'required': False},
                 {'prop_name': 'verification', 'prop_type': ValueTypes.ID,

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -154,6 +154,62 @@ class PropertyValidationTaskTests(unittest.TestCase):
         result, message, actions = validate_property(state, task)
         self.assertFalse(result, "Required property is not present; validation should fail.")
 
+    def test_basic_telephone_property_validation(self):
+        first_node = {
+            'id': 'http://example.com'
+        }
+        state = {
+            'graph': [first_node]
+        }
+        task = add_task(
+            VALIDATE_PROPERTY,
+            node_id=first_node['id'],
+            prop_name='tel',
+            required=True,
+            prop_type=ValueTypes.TELEPHONE
+        )
+
+        good_values = ["+64010", "+15417522845", "+18006664358", "+18006662344;ext=666"]
+        bad_values = ["1-800-666-DEVIL", "1 (555) 555-5555", "+99 55 22 1234", "+18006664343 x666"]
+
+        for tel_value in good_values:
+            first_node['tel'] = tel_value
+            result, message, actions = validate_property(state, task)
+            self.assertTrue(result)
+
+        for tel_value in bad_values:
+            first_node['tel'] = tel_value
+            result, message, actions = validate_property(state, task)
+            self.assertFalse(result)
+
+    def test_basic_email_property_validation(self):
+        first_node = {
+            'id': 'http://example.com'
+        }
+        state = {
+            'graph': [first_node]
+        }
+        task = add_task(
+            VALIDATE_PROPERTY,
+            node_id=first_node['id'],
+            prop_name='email',
+            required=True,
+            prop_type=ValueTypes.EMAIL
+        )
+
+        good_values = ["abc@localhost", "cool+uncool@example.org"]
+        bad_values = [" spacey@gmail.com", "steveman [at] gee mail dot com"]
+
+        for val in good_values:
+            first_node['email'] = val
+            result, message, actions = validate_property(state, task)
+            self.assertTrue(result, "{} should be marked a valid email".format(val))
+
+        for val in bad_values:
+            first_node['email'] = val
+            result, message, actions = validate_property(state, task)
+            self.assertFalse(result, "{} should be marked an invalid email".format(val))
+
     def test_basic_boolean_property_validation(self):
         first_node = {'id': 'http://example.com/1'}
         state = {


### PR DESCRIPTION
The email validator is very permissive.
The telephone validator enforces E.164 syntax and allows extensions like `+15556667777;ext=123`

Closes #106. Closes #107.