### PR TITLE
Add check for non-HTTP issuer profile IDs

### DIFF
--- a/badgecheck/actions/tasks.py
+++ b/badgecheck/actions/tasks.py
@@ -1,4 +1,5 @@
 from action_types import ADD_TASK, DELETE_TASK, REPORT_MESSAGE, RESOLVE_TASK, TRIGGER_CONDITION, UPDATE_TASK
+from ..utils import MESSAGE_LEVEL_INFO, MESSAGE_LEVELS
 
 
 def add_task(task_name, **kwargs):
@@ -53,8 +54,11 @@ def update_task(task_id, task_name, **kwargs):
     return task
 
 
-def report_message(msg):
+def report_message(msg, message_level=MESSAGE_LEVEL_INFO):
+    if message_level not in MESSAGE_LEVELS:
+        raise TypeError("message")
     return {
         'type': REPORT_MESSAGE,
-        'message': msg
+        'message': msg,
+        'messageLevel': message_level
     }

--- a/badgecheck/reducers/tasks.py
+++ b/badgecheck/reducers/tasks.py
@@ -24,7 +24,6 @@ def _task_to_add_exists(state, action):
                 action.get('url') == t.get('url')
             ][0]
 
-
         else:
             return False
     except IndexError:

--- a/badgecheck/state.py
+++ b/badgecheck/state.py
@@ -1,6 +1,6 @@
 import six
 
-from .utils import list_of
+from .utils import list_of, MESSAGE_LEVEL_ERROR, MESSAGE_LEVEL_INFO, MESSAGE_LEVEL_WARNING
 
 INITIAL_STATE = {
     'input': {},
@@ -8,11 +8,6 @@ INITIAL_STATE = {
     'tasks': [],
     'validationReport': {}
 }
-
-MESSAGE_LEVEL_ERROR = 'ERROR'
-MESSAGE_LEVEL_WARNING = 'WARNING'
-MESSAGE_LEVEL_INFO = 'INFO'
-MESSAGE_LEVELS = (MESSAGE_LEVEL_ERROR, MESSAGE_LEVEL_WARNING, MESSAGE_LEVEL_INFO,)
 
 
 # Tasks

--- a/badgecheck/state.py
+++ b/badgecheck/state.py
@@ -38,7 +38,7 @@ def filter_failed_tasks(state):
 def filter_messages_for_report(state):
     messages = []
     for t in state.get('tasks'):
-        if not t.get('success') or t.get('messageLevel') in [MESSAGE_LEVEL_INFO, MESSAGE_LEVEL_WARNING]:
+        if not t.get('success') or t.get('messageLevel') == MESSAGE_LEVEL_INFO:
             messages.append(t)
     return messages
 

--- a/badgecheck/tasks/__init__.py
+++ b/badgecheck/tasks/__init__.py
@@ -5,7 +5,7 @@ from .input import detect_input_type
 from .graph import fetch_http_node, jsonld_compact_data
 from .validation import (assertion_timestamp_checks, assertion_verification_dependencies,
                          criteria_property_dependencies, detect_and_validate_node_class,
-                         identity_object_property_dependencies, placeholder_task,
+                         identity_object_property_dependencies, issuer_property_dependencies, placeholder_task,
                          validate_expected_node_class, validate_rdf_type_property, validate_property,
                          validate_revocationlist_entries, )
 from .verification import (hosted_id_in_verification_scope, verify_recipient_against_trusted_profile)
@@ -23,7 +23,7 @@ FUNCTIONS = {
     HOSTED_ID_IN_VERIFICATION_SCOPE:           hosted_id_in_verification_scope,
     JSONLD_COMPACT_DATA:                       jsonld_compact_data,
     IDENTITY_OBJECT_PROPERTY_DEPENDENCIES:     identity_object_property_dependencies,
-    ISSUER_PROPERTY_DEPENDENCIES:              placeholder_task,
+    ISSUER_PROPERTY_DEPENDENCIES:              issuer_property_dependencies,
     PROCESS_JWS_INPUT:                         process_jws_input,
     VALIDATE_EXPECTED_NODE_CLASS:              validate_expected_node_class,
     VALIDATE_EXTENSION_NODE:                   validate_extension_node,

--- a/badgecheck/utils.py
+++ b/badgecheck/utils.py
@@ -7,6 +7,12 @@ import requests_cache
 from pyld.jsonld import JsonLdError
 
 
+MESSAGE_LEVEL_ERROR = 'ERROR'
+MESSAGE_LEVEL_WARNING = 'WARNING'
+MESSAGE_LEVEL_INFO = 'INFO'
+MESSAGE_LEVELS = (MESSAGE_LEVEL_ERROR, MESSAGE_LEVEL_WARNING, MESSAGE_LEVEL_INFO,)
+
+
 class CachableDocumentLoader(object):
     def __init__(self, use_cache=False, backend='memory', expire_after=300):
         self.use_cache = use_cache

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -20,9 +20,9 @@ from badgecheck.tasks.validation import (_get_validation_actions, assertion_time
 from badgecheck.tasks.verification import (_default_verification_policy, hosted_id_in_verification_scope,)
 from badgecheck.tasks.task_types import (ASSERTION_TIMESTAMP_CHECKS, CRITERIA_PROPERTY_DEPENDENCIES,
                                          DETECT_AND_VALIDATE_NODE_CLASS, HOSTED_ID_IN_VERIFICATION_SCOPE,
-                                         IDENTITY_OBJECT_PROPERTY_DEPENDENCIES, VALIDATE_RDF_TYPE_PROPERTY,
-                                         VALIDATE_PROPERTY, VALIDATE_EXPECTED_NODE_CLASS)
-
+                                         IDENTITY_OBJECT_PROPERTY_DEPENDENCIES, ISSUER_PROPERTY_DEPENDENCIES,
+                                         VALIDATE_RDF_TYPE_PROPERTY, VALIDATE_PROPERTY, VALIDATE_EXPECTED_NODE_CLASS)
+from badgecheck.utils import MESSAGE_LEVEL_WARNING
 from badgecheck.verifier import call_task, verify
 
 from testfiles.test_components import test_components
@@ -1208,5 +1208,25 @@ class IssuerClassValidationTests(unittest.TestCase):
         self.assertTrue(result)
 
         task_meta = add_task(DETECT_AND_VALIDATE_NODE_CLASS, node_id=issuer['id'])
+        result, message, actions = task_named(task_meta['name'])(state, task_meta)
+        self.assertTrue(result)
+
+    def test_issuer_warn_on_non_https_id(self):
+        issuer = {
+            '@context': OPENBADGES_CONTEXT_V2_DICT,
+            'id': 'urn:uuid:2d391246-6e0d-4dab-906c-b29770bd7aa6',
+            'type': 'Issuer',
+            'url': 'http://example.com'
+        }
+        state = {'graph': [issuer]}
+        task_meta = add_task(ISSUER_PROPERTY_DEPENDENCIES, node_id=issuer['id'],
+                             messageLevel=MESSAGE_LEVEL_WARNING)
+
+        result, message, actions = task_named(task_meta['name'])(state, task_meta)
+        self.assertFalse(result)
+        self.assertIn('HTTP', message)
+
+        issuer['id'] = 'http://example.org/issuer1'
+        task_meta['node_id'] = issuer['id']
         result, message, actions = task_named(task_meta['name'])(state, task_meta)
         self.assertTrue(result)


### PR DESCRIPTION
If the issuer Profile is embedded in the BadgeClass and doesn't use a HTTP ID, a warning will be raised.