### PR TITLE
Fixes #150 - Properly reports un-unbakeable images

### DIFF
--- a/badgecheck/actions/input.py
+++ b/badgecheck/actions/input.py
@@ -21,8 +21,8 @@ def set_input_type(type_string):
     :param input_type: string
     :return: dict
     """
-    if type_string not in ['url', 'json', 'jws']:
-        raise TypeError("Only 'url', 'json', or 'jws' input types supported.")
+    if type_string not in ['file', 'json', 'jws', 'url']:
+        raise TypeError("Only 'file', 'json', 'jws' or 'url' input types supported.")
 
     return {
         'type': SET_INPUT_TYPE,

--- a/badgecheck/verifier.py
+++ b/badgecheck/verifier.py
@@ -2,7 +2,7 @@ import json
 from openbadges_bakery import unbake
 from pydux import create_store
 
-from .actions.input import store_input
+from .actions.input import set_input_type, store_input
 from .actions.tasks import add_task, resolve_task, trigger_condition
 from .exceptions import SkipTask, TaskPrerequisitesError
 from .openbadges_context import OPENBADGES_CONTEXT_V2_URI
@@ -80,17 +80,24 @@ def call_task(task_func, task_meta, store, options=DEFAULT_OPTIONS):
 def verification_store(badge_input, recipient_profile=None, store=None, options=DEFAULT_OPTIONS):
     if store is None:
         store = create_store(main_reducer, INITIAL_STATE)
-
-    if hasattr(badge_input, 'read') and hasattr(badge_input, 'seek'):
-        badge_input.seek(0)
-        badge_data = unbake(badge_input)
-        if not badge_data:
-            raise ValueError("Files as badge input must be baked images.")
+    try:
+        if hasattr(badge_input, 'read') and hasattr(badge_input, 'seek'):
+            badge_input.seek(0)
+            badge_data = unbake(badge_input)
+            if not badge_data:
+                raise ValueError("Could not find Open Badges metadata in file.")
+        else:
+            badge_data = badge_input
+    except ValueError as e:
+        # Could not obtain badge data from input. Set the result as a failed DETECT_INPUT_TYPE task.
+        store.dispatch(store_input(badge_input.name))
+        store.dispatch(add_task(tasks.DETECT_INPUT_TYPE))
+        store.dispatch(set_input_type('file'))
+        task = store.get_state()['tasks'][0]
+        store.dispatch(resolve_task(task.get('task_id'), success=False, result=e.message))
     else:
-        badge_data = badge_input
-
-    store.dispatch(store_input(badge_data))
-    store.dispatch(add_task(tasks.DETECT_INPUT_TYPE))
+        store.dispatch(store_input(badge_data))
+        store.dispatch(add_task(tasks.DETECT_INPUT_TYPE))
 
     if recipient_profile:
         profile_id = recipient_profile.get('id')


### PR DESCRIPTION
Fixes #150 - Properly reports un-unbakeable images in the same "failed task" format as other errors. No longer a server 500 error when using the HTTP API or web front-end.